### PR TITLE
Implement horizontal & vertical layouts with Spectrum elements #13 #14

### DIFF
--- a/packages/spectrum/src/layouts/GroupLayout.tsx
+++ b/packages/spectrum/src/layouts/GroupLayout.tsx
@@ -43,15 +43,15 @@ export const GroupLayoutRenderer: FunctionComponent<RendererProps & VanillaRende
     uischema,
     path,
     visible,
-    getStyle,
+    // getStyle,
     getStyleAsClassName
   }: RendererProps & VanillaRendererProps) => {
   const group = uischema as GroupLayout;
-  const elementsSize = group.elements ? group.elements.length : 0;
+  // const elementsSize = group.elements ? group.elements.length : 0;
   const classNames = getStyleAsClassName('group.layout');
-  const childClassNames = getStyle('group.layout.item', elementsSize)
-    .concat(['group-layout-item'])
-    .join(' ');
+  // const childClassNames = getStyle('group.layout.item', elementsSize)
+  //   .concat(['group-layout-item'])
+  //   .join(' ');
 
   return (
     <fieldset
@@ -64,7 +64,7 @@ export const GroupLayoutRenderer: FunctionComponent<RendererProps & VanillaRende
             {group.label}
           </legend> : ''
       }
-      {renderChildren(group, schema, childClassNames, path)}
+      {renderChildren(group, schema, /*childClassNames*/ {}, path)}
     </fieldset>
   );
 };

--- a/packages/spectrum/src/layouts/HorizontalLayout.tsx
+++ b/packages/spectrum/src/layouts/HorizontalLayout.tsx
@@ -31,10 +31,10 @@ import {
   uiTypeIs
 } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { StyleProps } from '@react-types/shared';
 import { withVanillaControlProps } from '../util';
 import { JsonFormsLayout } from './JsonFormsLayout';
 import { renderChildren } from './util';
-import { VanillaRendererProps } from '../index';
 
 /**
  * Default tester for a horizontal layout.
@@ -42,37 +42,34 @@ import { VanillaRendererProps } from '../index';
  */
 export const horizontalLayoutTester: RankedTester = rankWith(1, uiTypeIs('HorizontalLayout'));
 
-const HorizontalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> = (
+const HorizontalLayoutRenderer: FunctionComponent<RendererProps> = (
   {
     schema,
     uischema,
-    getStyle,
-    getStyleAsClassName,
     enabled,
     visible,
     path
-  }: RendererProps & VanillaRendererProps
+  }: RendererProps
 ) => {
 
   const horizontalLayout = uischema as HorizontalLayout;
-  const elementsSize = horizontalLayout.elements ? horizontalLayout.elements.length : 0;
-  const layoutClassName = getStyleAsClassName('horizontal.layout');
-  const childClassNames = getStyle('horizontal.layout.item', elementsSize)
-    .concat(['horizontal-layout-item'])
-    .join(' ');
+  const direction = 'row';
+  const childrenStyles: StyleProps = {
+    flexGrow: 1,
+    maxWidth: '100%',
+    flexBasis: 0,
+  };
 
   return (
     <JsonFormsLayout
-      className={layoutClassName}
+      direction={direction}
       visible={visible}
       enabled={enabled}
       path={path}
       uischema={uischema}
       schema={schema}
-      getStyle={getStyle}
-      getStyleAsClassName={getStyleAsClassName}
     >
-      {renderChildren(horizontalLayout, schema, childClassNames, path)}
+      {renderChildren(horizontalLayout, schema, childrenStyles, path)}
     </JsonFormsLayout>
   );
 };

--- a/packages/spectrum/src/layouts/JsonFormsLayout.tsx
+++ b/packages/spectrum/src/layouts/JsonFormsLayout.tsx
@@ -24,19 +24,21 @@
 */
 import React from 'react';
 import { RendererProps } from '@jsonforms/core';
-import { VanillaRendererProps, WithChildren } from '../index';
+import { Flex } from '@adobe/react-spectrum';
+import { FlexProps } from '@react-types/layout';
 
 // tslint:disable:variable-name
 export const JsonFormsLayout =
-    ({ className, children, visible }: RendererProps & VanillaRendererProps & WithChildren) => {
+    ({ children, visible, ...flexProps }: RendererProps & FlexProps) => {
 // tslint:enable:variable-name
 
   return (
-    <div
-      className={className}
-      hidden={visible === undefined || visible === null ? false : !visible}
+    <Flex
+      isHidden={visible === undefined || visible === null ? false : !visible}
+      gap='size-100'
+      {...flexProps}
     >
       {children}
-    </div>
+    </Flex>
   );
 };

--- a/packages/spectrum/src/layouts/VerticalLayout.tsx
+++ b/packages/spectrum/src/layouts/VerticalLayout.tsx
@@ -31,10 +31,10 @@ import {
   VerticalLayout
 } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { StyleProps } from '@react-types/shared';
 import { withVanillaControlProps } from '../util';
 import { JsonFormsLayout } from './JsonFormsLayout';
 import { renderChildren } from './util';
-import { VanillaRendererProps } from '../index';
 
 /**
  * Default tester for a vertical layout.
@@ -42,36 +42,33 @@ import { VanillaRendererProps } from '../index';
  */
 export const verticalLayoutTester: RankedTester = rankWith(1, uiTypeIs('VerticalLayout'));
 
-export const VerticalLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> = (
+export const VerticalLayoutRenderer: FunctionComponent<RendererProps> = (
   {
     schema,
     uischema,
     path,
     visible,
     enabled,
-    getStyle,
-    getStyleAsClassName
-  }: RendererProps & VanillaRendererProps) => {
+  }: RendererProps) => {
 
   const verticalLayout = uischema as VerticalLayout;
-  const elementsSize = verticalLayout.elements ? verticalLayout.elements.length : 0;
-  const layoutClassName = getStyleAsClassName('vertical.layout');
-  const childClassNames = getStyle('vertical.layout.item', elementsSize)
-    .concat(['vertical-layout-item'])
-    .join(' ');
+  const direction = 'column';
+  const childrenStyles: StyleProps = {
+    flexGrow: 1,
+    maxWidth: '100%',
+    flexBasis: 0,
+  };
 
   return (
     <JsonFormsLayout
-      className={layoutClassName}
+      direction={direction}
       uischema={uischema}
       schema={schema}
       visible={visible}
       enabled={enabled}
       path={path}
-      getStyle={getStyle}
-      getStyleAsClassName={getStyleAsClassName}
     >
-      {renderChildren(verticalLayout, schema, childClassNames, path)}
+      {renderChildren(verticalLayout, schema, childrenStyles, path)}
     </JsonFormsLayout>
   );
 };

--- a/packages/spectrum/src/layouts/util.tsx
+++ b/packages/spectrum/src/layouts/util.tsx
@@ -26,17 +26,20 @@ import isEmpty from 'lodash/isEmpty';
 import React from 'react';
 import { JsonSchema, Layout } from '@jsonforms/core';
 import { ResolvedJsonFormsDispatch, useJsonForms } from '@jsonforms/react';
+import { StyleProps } from '@react-types/shared';
+import { View } from '@adobe/react-spectrum';
+
 export interface RenderChildrenProps {
   layout: Layout;
   schema: JsonSchema;
-  className: string;
+  styles: StyleProps;
   path: string;
 }
 
 export const renderChildren = (
   layout: Layout,
   schema: JsonSchema,
-  className: string,
+  styles: StyleProps,
   path: string
 ) => {
   if (isEmpty(layout.elements)) {
@@ -47,7 +50,7 @@ export const renderChildren = (
 
   return layout.elements.map((child, index) => {
     return (
-      <div className={className} key={`${path}-${index}`}>
+      <View key={`${path}-${index}`} {...styles}>
         <ResolvedJsonFormsDispatch
           renderers={renderers}
           cells={cells}
@@ -55,7 +58,7 @@ export const renderChildren = (
           schema={schema}
           path={path}
         />
-      </div>
+      </View>
     );
   });
 };

--- a/packages/spectrum/test/renderers/HorizontalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/HorizontalLayout.test.tsx
@@ -82,8 +82,7 @@ describe('Horizontal layout', () => {
       </Provider>
     );
 
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
-
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div');
     expect(horizontalLayout).toBeDefined();
     expect(horizontalLayout.children).toHaveLength(0);
   });
@@ -106,7 +105,7 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div') as HTMLDivElement;
     expect(horizontalLayout).toBeDefined();
     expect(horizontalLayout.children).toHaveLength(0);
   });
@@ -132,7 +131,7 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div');
     expect(horizontalLayout).toBeDefined();
     expect(horizontalLayout.children).toHaveLength(2);
   });
@@ -155,7 +154,7 @@ describe('Horizontal layout', () => {
       </Provider>
     );
     const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
-    expect(horizontalLayout.hidden).toBe(true);
+    expect(horizontalLayout.style.display).toBe('none');
   });
 
   test('show by default', () => {
@@ -173,6 +172,6 @@ describe('Horizontal layout', () => {
       </Provider>
     );
     const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
-    expect(horizontalLayout.hidden).toBe(false);
+    expect(horizontalLayout.style.display).not.toBe('none');
   });
 });

--- a/packages/spectrum/test/renderers/VerticalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/VerticalLayout.test.tsx
@@ -70,7 +70,10 @@ describe('Vertical layout', () => {
       </Provider>
     );
 
-    expect(wrapper.find('.vertical-layout')).toBeDefined();
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
+
+    expect(verticalLayout).toBeDefined();
+    expect(verticalLayout.children).toHaveLength(0);
   });
 
   test('render with null elements', () => {
@@ -92,7 +95,9 @@ describe('Vertical layout', () => {
       </Provider>
     );
 
-    expect(wrapper.find('.vertical-layout')).toBeDefined();
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
+    expect(verticalLayout).toBeDefined();
+    expect(verticalLayout.children).toHaveLength(0);
   });
 
   test('render with children', () => {
@@ -113,9 +118,8 @@ describe('Vertical layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode();
-
-    expect(verticalLayout.tagName).toBe('DIV');
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
+    expect(verticalLayout).toBeDefined();
     expect(verticalLayout.children).toHaveLength(2);
   });
 
@@ -142,7 +146,7 @@ describe('Vertical layout', () => {
       </Provider>
     );
     const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLDivElement;
-    expect(verticalLayout.hidden).toBe(true);
+    expect(verticalLayout.style.display).toBe('none');
   });
 
   test('show by default', () => {
@@ -165,6 +169,6 @@ describe('Vertical layout', () => {
       </Provider>
     );
     const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLDivElement;
-    expect(verticalLayout.hidden).toBe(false);
+    expect(verticalLayout.style.display).not.toBe('none');
   });
 });


### PR DESCRIPTION
@mburri Ich habe mich noch gefragt, ob die Inputs nicht immer auf 100% gehen sollten:

![image](https://user-images.githubusercontent.com/66047/95839296-259dca80-0d43-11eb-8154-07214a118fe2.png)

Siehe z.B. https://jsonforms.io/examples/layouts#horizontal-layout

Ausserdem sollten wir uns mal `addVanillaControlProps` und `initJsonFormsVanillaStore` anschauen. Die ganze Klassengeschichte (`vanillaStyles`) braucht es ja nicht bei uns.