### PR TITLE
Implement group layout with Spectrum elements #15

### DIFF
--- a/packages/spectrum/src/layouts/GroupLayout.tsx
+++ b/packages/spectrum/src/layouts/GroupLayout.tsx
@@ -26,8 +26,8 @@ import isEmpty from 'lodash/isEmpty';
 import React, { FunctionComponent } from 'react';
 import { GroupLayout, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
+import { View, Heading, Divider, Content } from '@adobe/react-spectrum';
 import { renderChildren } from './util';
-import { VanillaRendererProps } from '../index';
 import { withVanillaControlProps } from '../util';
 
 /**
@@ -37,35 +37,33 @@ import { withVanillaControlProps } from '../util';
  */
 export const groupTester: RankedTester = rankWith(1, uiTypeIs('Group'));
 
-export const GroupLayoutRenderer: FunctionComponent<RendererProps & VanillaRendererProps> = (
+export const GroupLayoutRenderer: FunctionComponent<RendererProps> = (
   {
     schema,
     uischema,
     path,
     visible,
-    // getStyle,
-    getStyleAsClassName
-  }: RendererProps & VanillaRendererProps) => {
+  }: RendererProps) => {
   const group = uischema as GroupLayout;
-  // const elementsSize = group.elements ? group.elements.length : 0;
-  const classNames = getStyleAsClassName('group.layout');
-  // const childClassNames = getStyle('group.layout.item', elementsSize)
-  //   .concat(['group-layout-item'])
-  //   .join(' ');
 
   return (
-    <fieldset
-      className={classNames}
-      hidden={visible === undefined || visible === null ? false : !visible}
+    <View
+      isHidden={visible === undefined || visible === null ? false : !visible}
+      borderWidth='thin'
+      borderColor='dark'
+      borderRadius='medium'
+      padding='size-250'
     >
       {
-        !isEmpty(group.label) ?
-          <legend className={getStyleAsClassName('group.label')}>
-            {group.label}
-          </legend> : ''
+        !isEmpty(group.label)
+          ? <Heading level={4} margin={0}>{group.label}</Heading>
+          : ''
       }
-      {renderChildren(group, schema, /*childClassNames*/ {}, path)}
-    </fieldset>
+      <Divider size='M' marginTop='size-150' marginBottom='size-200' />
+      <Content>
+        {renderChildren(group, schema, {}, path)}
+      </Content>
+    </View>
   );
 };
 

--- a/packages/spectrum/src/layouts/util.tsx
+++ b/packages/spectrum/src/layouts/util.tsx
@@ -32,14 +32,14 @@ import { View } from '@adobe/react-spectrum';
 export interface RenderChildrenProps {
   layout: Layout;
   schema: JsonSchema;
-  styles: StyleProps;
+  styleProps: StyleProps;
   path: string;
 }
 
 export const renderChildren = (
   layout: Layout,
   schema: JsonSchema,
-  styles: StyleProps,
+  styleProps: StyleProps,
   path: string
 ) => {
   if (isEmpty(layout.elements)) {
@@ -50,7 +50,7 @@ export const renderChildren = (
 
   return layout.elements.map((child, index) => {
     return (
-      <View key={`${path}-${index}`} {...styles}>
+      <View key={`${path}-${index}`} {...styleProps}>
         <ResolvedJsonFormsDispatch
           renderers={renderers}
           cells={cells}

--- a/packages/spectrum/test/renderers/GroupLayout.test.tsx
+++ b/packages/spectrum/test/renderers/GroupLayout.test.tsx
@@ -38,12 +38,6 @@ const fixture = {
     type: 'Group',
     elements: [{ type: 'Control' }]
   },
-  styles: [
-    {
-      name: 'group.layout',
-      classNames: ['group-layout']
-    }
-  ]
 };
 
 test('tester', () => {
@@ -59,6 +53,28 @@ describe('Group layout', () => {
 
   afterEach(() => wrapper.unmount());
 
+  test('render without label', () => {
+    const uischema: GroupLayout = {
+      type: 'Group',
+      elements: [],
+    };
+    const store = initJsonFormsVanillaStore({
+      data: {},
+      schema: {},
+      uischema,
+    });
+    wrapper = mount(
+      <Provider store={store}>
+        <JsonFormsReduxContext>
+          <GroupLayoutRenderer uischema={uischema} />
+        </JsonFormsReduxContext>
+      </Provider>
+    );
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode();
+    const heading = groupLayout.querySelector('h4');
+    expect(heading).toBeNull();
+  });
+  
   test('render with label', () => {
     const uischema: GroupLayout = {
       type: 'Group',
@@ -69,7 +85,6 @@ describe('Group layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -78,14 +93,9 @@ describe('Group layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const groupLayout = wrapper.find('.group-layout').getDOMNode();
-    const legend = groupLayout.children[0];
-
-    expect(groupLayout.tagName).toBe('FIELDSET');
-    expect(groupLayout.className).toBe('group-layout');
-    expect(groupLayout.children).toHaveLength(1);
-    expect(legend.tagName).toBe('LEGEND');
-    expect(legend.textContent).toBe('Foo');
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode();
+    const heading = groupLayout.querySelector('h4');
+    expect(heading?.textContent).toBe('Foo');
   });
 
   test('render with null elements', () => {
@@ -97,7 +107,6 @@ describe('Group layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -106,9 +115,9 @@ describe('Group layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const groupLayout = wrapper.find('.group-layout').getDOMNode();
-    expect(groupLayout.tagName).toBe('FIELDSET');
-    expect(groupLayout.children).toHaveLength(0);
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode();
+    const content = groupLayout.querySelector('section');
+    expect(content?.children).toHaveLength(0);
   });
 
   test('render with children', () => {
@@ -123,7 +132,6 @@ describe('Group layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -132,9 +140,9 @@ describe('Group layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const groupLayout = wrapper.find('.group-layout').getDOMNode();
-    expect(groupLayout.tagName).toBe('FIELDSET');
-    expect(groupLayout.children).toHaveLength(2);
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode();
+    const content = groupLayout.querySelector('section');
+    expect(content?.children).toHaveLength(2);
   });
 
   test('hide', () => {
@@ -142,7 +150,6 @@ describe('Group layout', () => {
       data: {},
       schema: {},
       uischema: fixture.uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -154,8 +161,9 @@ describe('Group layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const groupLayout = wrapper.find('.group-layout');
-    expect(groupLayout.props().hidden).toBe(true);
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode() as HTMLElement
+;
+    expect(groupLayout.style.display).toBe('none');
   });
 
   test('show by default', () => {
@@ -163,7 +171,6 @@ describe('Group layout', () => {
       data: {},
       schema: {},
       uischema: fixture.uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -172,7 +179,8 @@ describe('Group layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const groupLayout = wrapper.find('.group-layout');
-    expect(groupLayout.props().hidden).toBe(false);
+    const groupLayout = wrapper.find(GroupLayoutRenderer).getDOMNode() as HTMLElement
+;
+    expect(groupLayout.style.display).not.toBe('none');
   });
 });

--- a/packages/spectrum/test/renderers/HorizontalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/HorizontalLayout.test.tsx
@@ -43,12 +43,6 @@ const fixture = {
     type: 'HorizontalLayout',
     elements: [{ type: 'Control' }]
   },
-  styles: [
-    {
-      name: 'horizontal.layout',
-      classNames: ['horizontal-layout']
-    }
-  ]
 };
 
 test('tester', () => {
@@ -72,7 +66,6 @@ describe('Horizontal layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -82,9 +75,8 @@ describe('Horizontal layout', () => {
       </Provider>
     );
 
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div');
-    expect(horizontalLayout).toBeDefined();
-    expect(horizontalLayout.children).toHaveLength(0);
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().firstElementChild;
+    expect(horizontalLayout?.children).toHaveLength(0);
   });
 
   test('render with null elements', () => {
@@ -96,7 +88,6 @@ describe('Horizontal layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -105,9 +96,8 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div') as HTMLDivElement;
-    expect(horizontalLayout).toBeDefined();
-    expect(horizontalLayout.children).toHaveLength(0);
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().firstElementChild;
+    expect(horizontalLayout?.children).toHaveLength(0);
   });
 
   test('render with children', () => {
@@ -122,7 +112,6 @@ describe('Horizontal layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -131,9 +120,8 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().querySelector('div');
-    expect(horizontalLayout).toBeDefined();
-    expect(horizontalLayout.children).toHaveLength(2);
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode().firstElementChild;
+    expect(horizontalLayout?.children).toHaveLength(2);
   });
 
   test('hide', () => {
@@ -141,7 +129,6 @@ describe('Horizontal layout', () => {
       data: {},
       schema: {},
       uischema: fixture.uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -153,7 +140,7 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(horizontalLayout.style.display).toBe('none');
   });
 
@@ -162,7 +149,6 @@ describe('Horizontal layout', () => {
       data: {},
       schema: {},
       uischema: fixture.uischema,
-      styles: fixture.styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -171,7 +157,7 @@ describe('Horizontal layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const horizontalLayout = wrapper.find(HorizontalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(horizontalLayout.style.display).not.toBe('none');
   });
 });

--- a/packages/spectrum/test/renderers/VerticalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/VerticalLayout.test.tsx
@@ -33,13 +33,6 @@ import { initJsonFormsVanillaStore } from '../vanillaStore';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const styles = [
-  {
-    name: 'vertical.layout',
-    classNames: ['vertical-layout']
-  }
-];
-
 test('tester', () => {
   expect(verticalLayoutTester(undefined, undefined)).toBe(-1);
   expect(verticalLayoutTester(null, undefined)).toBe(-1);
@@ -70,10 +63,9 @@ describe('Vertical layout', () => {
       </Provider>
     );
 
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().firstElementChild as HTMLDivElement;
 
-    expect(verticalLayout).toBeDefined();
-    expect(verticalLayout.children).toHaveLength(0);
+    expect(verticalLayout?.children).toHaveLength(0);
   });
 
   test('render with null elements', () => {
@@ -85,7 +77,6 @@ describe('Vertical layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -95,9 +86,8 @@ describe('Vertical layout', () => {
       </Provider>
     );
 
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
-    expect(verticalLayout).toBeDefined();
-    expect(verticalLayout.children).toHaveLength(0);
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().firstElementChild;
+    expect(verticalLayout?.children).toHaveLength(0);
   });
 
   test('render with children', () => {
@@ -109,7 +99,6 @@ describe('Vertical layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles
     });
     wrapper = mount(
       <Provider store={store}>
@@ -118,9 +107,8 @@ describe('Vertical layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().querySelector('div');
-    expect(verticalLayout).toBeDefined();
-    expect(verticalLayout.children).toHaveLength(2);
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode().firstElementChild;
+    expect(verticalLayout?.children).toHaveLength(2);
   });
 
   test('hide', () => {
@@ -132,7 +120,6 @@ describe('Vertical layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles
     });
 
     wrapper = mount(
@@ -145,7 +132,7 @@ describe('Vertical layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(verticalLayout.style.display).toBe('none');
   });
 
@@ -158,7 +145,6 @@ describe('Vertical layout', () => {
       data: {},
       schema: {},
       uischema,
-      styles,
     });
 
     wrapper = mount(
@@ -168,7 +154,7 @@ describe('Vertical layout', () => {
         </JsonFormsReduxContext>
       </Provider>
     );
-    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLDivElement;
+    const verticalLayout = wrapper.find(VerticalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(verticalLayout.style.display).not.toBe('none');
   });
 });


### PR DESCRIPTION
@mburri 

Da es keine komplette Spectrum Komponente dafür gibt, habe ich die Umsetzung an das `View` Beispiel (https://react-spectrum.adobe.com/react-spectrum/View.html#example) und den `Dialog` (https://react-spectrum.adobe.com/react-spectrum/Dialog.html#example) angelehnt:

![image](https://user-images.githubusercontent.com/66047/95856812-ee3b1800-0d5a-11eb-896a-35f0473b3817.png)
