### PR TITLE
Rewrite horizontal layout test without redux

### DIFF
--- a/packages/spectrum/test/renderers/SpectrumHorizontalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/SpectrumHorizontalLayout.test.tsx
@@ -25,19 +25,18 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import * as React from 'react';
 import {
   HorizontalLayout,
-  UISchemaElement
+  UISchemaElement,
+  RuleEffect,
+  SchemaBasedCondition
 } from '@jsonforms/core';
-import { Provider } from 'react-redux';
 import Adapter from 'enzyme-adapter-react-16';
-import Enzyme, { mount, ReactWrapper } from 'enzyme';
+import Enzyme, { ReactWrapper } from 'enzyme';
 import SpectrumHorizontalLayoutRenderer, {
   spectrumHorizontalLayoutTester
 } from '../../src/layouts/SpectrumHorizontalLayout';
-import { initJsonFormsVanillaStore } from '../vanillaStore';
-import { JsonFormsReduxContext } from '@jsonforms/react';
+import { mountForm } from '../util';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -65,18 +64,7 @@ describe('Horizontal layout', () => {
     const uischema: UISchemaElement = {
       type: 'HorizontalLayout'
     };
-    const store = initJsonFormsVanillaStore({
-      data: {},
-      schema: {},
-      uischema,
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <SpectrumHorizontalLayoutRenderer uischema={uischema} />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
+    wrapper = mountForm(uischema);
 
     const horizontalLayout = wrapper.find(SpectrumHorizontalLayoutRenderer).getDOMNode().firstElementChild;
     expect(horizontalLayout?.children).toHaveLength(0);
@@ -87,18 +75,7 @@ describe('Horizontal layout', () => {
       type: 'HorizontalLayout',
       elements: null
     };
-    const store = initJsonFormsVanillaStore({
-      data: {},
-      schema: {},
-      uischema,
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <SpectrumHorizontalLayoutRenderer uischema={uischema} />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
+    wrapper = mountForm(uischema);
     const horizontalLayout = wrapper.find(SpectrumHorizontalLayoutRenderer).getDOMNode().firstElementChild;
     expect(horizontalLayout?.children).toHaveLength(0);
   });
@@ -111,55 +88,31 @@ describe('Horizontal layout', () => {
         { type: 'Control' }
       ]
     };
-    const store = initJsonFormsVanillaStore({
-      data: {},
-      schema: {},
-      uischema,
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <SpectrumHorizontalLayoutRenderer uischema={uischema} />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
+    wrapper = mountForm(uischema);
     const horizontalLayout = wrapper.find(SpectrumHorizontalLayoutRenderer).getDOMNode().firstElementChild;
     expect(horizontalLayout?.children).toHaveLength(2);
   });
 
   test('hide', () => {
-    const store = initJsonFormsVanillaStore({
-      data: {},
+    // Condition that evaluates to false
+    const condition: SchemaBasedCondition = {
+      scope: '',
       schema: {},
-      uischema: fixture.uischema,
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <SpectrumHorizontalLayoutRenderer
-            uischema={fixture.uischema}
-            visible={false}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
+    };
+    const uischema: UISchemaElement = {
+      ...fixture.uischema,
+      rule: {
+        effect: RuleEffect.HIDE,
+        condition
+      }
+    };
+    wrapper = mountForm(uischema);
     const horizontalLayout = wrapper.find(SpectrumHorizontalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(horizontalLayout.style.display).toBe('none');
   });
 
   test('show by default', () => {
-    const store = initJsonFormsVanillaStore({
-      data: {},
-      schema: {},
-      uischema: fixture.uischema,
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <SpectrumHorizontalLayoutRenderer uischema={fixture.uischema} />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
+    wrapper = mountForm(fixture.uischema);
     const horizontalLayout = wrapper.find(SpectrumHorizontalLayoutRenderer).getDOMNode() as HTMLElement;
     expect(horizontalLayout.style.display).not.toBe('none');
   });

--- a/packages/spectrum/test/util.tsx
+++ b/packages/spectrum/test/util.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import { UISchemaElement, JsonSchema } from '@jsonforms/core';
+import { JsonForms } from '@jsonforms/react';
+import { vanillaRenderers } from '../src/index';
+
+export function mountForm(
+  uischema: UISchemaElement,
+  schema: JsonSchema = {},
+  data: any = {}
+): ReactWrapper {
+  return mount(
+    <JsonForms
+      schema={schema}
+      uischema={uischema}
+      data={data}
+      renderers={vanillaRenderers}
+    />
+  );
+}


### PR DESCRIPTION
Hier ist mal ein Versuch anhand des `SpectrumHorizontalLayout` Tests diesen ohne `JsonFormsReduxContext`, nur mit `JsonForms`, umzusetzen.

Ich habe dazu die Helper Function `mountForm` erstellt, da sich der Markup nun nicht mehr ändert. D.h. aber auch, man kann dem Renderer keine Props mehr reingeben, wie z.B. `visible={false}`. In diesem konkreten Fall musste ich eine dummy _Rule_ erstellen, die das Element hided. Vielleicht ist dies der Grund, weshalb die Tests den `JsonFormsReduxContext` verwenden? Ich habe allerdings einzig `visible`, `path` und `enabled` gesehen, die so gesetzt werden. Manche Tests verwenden auch noch den `SpectrumThemeProvider`, das sollte aber wahrscheinlich auch gehen mit `JsonForms` (habe es nicht getestet).

@mburri Was meinst du?