### PR TITLE
Migrate Label Renderer to react-spectrum

### DIFF
--- a/packages/spectrum/src/complex/LabelRenderer.tsx
+++ b/packages/spectrum/src/complex/LabelRenderer.tsx
@@ -4,6 +4,9 @@
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
 
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
@@ -23,10 +26,16 @@
   THE SOFTWARE.
 */
 import React, { FunctionComponent } from 'react';
-import { LabelElement, RankedTester, rankWith, RendererProps, uiTypeIs } from '@jsonforms/core';
+import {
+  LabelElement,
+  RankedTester,
+  rankWith,
+  RendererProps,
+  uiTypeIs,
+} from '@jsonforms/core';
 import { withJsonFormsLayoutProps } from '@jsonforms/react';
-import { VanillaRendererProps } from '../index';
 import { withVanillaControlProps } from '../util';
+import { Text, View } from '@adobe/react-spectrum';
 
 /**
  * Default tester for a label.
@@ -37,20 +46,23 @@ export const labelRendererTester: RankedTester = rankWith(1, uiTypeIs('Label'));
 /**
  * Default renderer for a label.
  */
-export const LabelRenderer: FunctionComponent<RendererProps & VanillaRendererProps> =
-  ({ uischema, visible, getStyleAsClassName }) => {
-    const labelElement: LabelElement = uischema as LabelElement;
-    const classNames = getStyleAsClassName('label-control');
-    const isHidden = !visible;
+export const LabelRenderer: FunctionComponent<RendererProps> = ({
+  uischema,
+  visible,
+}) => {
+  const labelElement: LabelElement = uischema as LabelElement;
 
-    return (
-      <label
-        hidden={isHidden}
-        className={classNames}
-      >
-        {labelElement.text !== undefined && labelElement.text !== null && labelElement.text}
-      </label>
-    );
-  };
+  const isHidden = !visible;
+
+  return (
+    <View isHidden={isHidden}>
+      <Text>
+        {labelElement.text !== undefined &&
+          labelElement.text !== null &&
+          labelElement.text}
+      </Text>
+    </View>
+  );
+};
 
 export default withVanillaControlProps(withJsonFormsLayoutProps(LabelRenderer));

--- a/packages/spectrum/src/complex/SpectrumLabelRenderer.tsx
+++ b/packages/spectrum/src/complex/SpectrumLabelRenderer.tsx
@@ -41,12 +41,15 @@ import { Text, View } from '@adobe/react-spectrum';
  * Default tester for a label.
  * @type {RankedTester}
  */
-export const labelRendererTester: RankedTester = rankWith(1, uiTypeIs('Label'));
+export const spectrumLabelRendererTester: RankedTester = rankWith(
+  1,
+  uiTypeIs('Label')
+);
 
 /**
  * Default renderer for a label.
  */
-export const LabelRenderer: FunctionComponent<RendererProps> = ({
+export const SpectrumLabelRenderer: FunctionComponent<RendererProps> = ({
   uischema,
   visible,
 }) => {
@@ -65,4 +68,6 @@ export const LabelRenderer: FunctionComponent<RendererProps> = ({
   );
 };
 
-export default withVanillaControlProps(withJsonFormsLayoutProps(LabelRenderer));
+export default withVanillaControlProps(
+  withJsonFormsLayoutProps(SpectrumLabelRenderer)
+);

--- a/packages/spectrum/src/complex/index.ts
+++ b/packages/spectrum/src/complex/index.ts
@@ -27,7 +27,9 @@ import SpectrumObjectRenderer, {
 } from './SpectrumObjectRenderer';
 import ArrayControl, { arrayControlTester } from './array';
 import Categorization, { categorizationTester } from './categorization';
-import LabelRenderer, { labelRendererTester } from './LabelRenderer';
+import SpectrumLabelRenderer, {
+  spectrumLabelRendererTester,
+} from './SpectrumLabelRenderer';
 import TableArrayControl, {
   tableArrayControlTester,
 } from './TableArrayControl';
@@ -37,8 +39,8 @@ export {
   arrayControlTester,
   Categorization,
   categorizationTester,
-  LabelRenderer,
-  labelRendererTester,
+  SpectrumLabelRenderer,
+  spectrumLabelRendererTester,
   SpectrumObjectRenderer,
   spectrumObjectControlTester,
   TableArrayControl,

--- a/packages/spectrum/src/index.ts
+++ b/packages/spectrum/src/index.ts
@@ -68,8 +68,8 @@ import {
   arrayControlTester,
   Categorization,
   categorizationTester,
-  LabelRenderer,
-  labelRendererTester,
+  SpectrumLabelRenderer,
+  spectrumLabelRendererTester,
   spectrumObjectControlTester,
   SpectrumObjectRenderer,
   TableArrayControl,
@@ -141,13 +141,16 @@ export const vanillaRenderers: { tester: RankedTester; renderer: any }[] = [
   { tester: spectrumTextAreaControlTester, renderer: SpectrumTextAreaControl },
   { tester: spectrumTextControlTester, renderer: SpectrumTextControl },
   { tester: arrayControlTester, renderer: ArrayControl },
-  { tester: labelRendererTester, renderer: LabelRenderer },
+  { tester: spectrumLabelRendererTester, renderer: SpectrumLabelRenderer },
   { tester: categorizationTester, renderer: Categorization },
   { tester: spectrumObjectControlTester, renderer: SpectrumObjectRenderer },
   { tester: tableArrayControlTester, renderer: TableArrayControl },
   { tester: spectrumGroupLayoutTester, renderer: SpectrumGroupLayout },
   { tester: spectrumVerticalLayoutTester, renderer: SpectrumVerticalLayout },
-  { tester: spectrumHorizontalLayoutTester, renderer: SpectrumHorizontalLayout },
+  {
+    tester: spectrumHorizontalLayoutTester,
+    renderer: SpectrumHorizontalLayout,
+  },
 ];
 
 export const vanillaCells: { tester: RankedTester; cell: any }[] = [

--- a/packages/spectrum/test/renderers/LabelControl.test.tsx
+++ b/packages/spectrum/test/renderers/LabelControl.test.tsx
@@ -3,6 +3,9 @@
   
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
+
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
   
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -22,16 +25,16 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import * as React from 'react';
-import { LabelElement, UISchemaElement } from '@jsonforms/core';
-import { JsonFormsReduxContext } from '@jsonforms/react';
-import { Provider } from 'react-redux';
+import {
+  LabelElement,
+  RuleEffect,
+  SchemaBasedCondition,
+  UISchemaElement,
+} from '@jsonforms/core';
 import Adapter from 'enzyme-adapter-react-16';
-import Enzyme, { mount, ReactWrapper } from 'enzyme';
-import LabelRenderer, {
-  labelRendererTester
-} from '../../src/complex/LabelRenderer';
-import { initJsonFormsVanillaStore } from '../vanillaStore';
+import Enzyme, { ReactWrapper } from 'enzyme';
+import { labelRendererTester } from '../../src/complex/LabelRenderer';
+import { mountForm } from '../util';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -39,15 +42,15 @@ const fixture = {
   data: { name: 'Foo' },
   schema: {
     type: 'object',
-    properties: { name: { type: 'string' } }
+    properties: { name: { type: 'string' } },
   },
   uischema: { type: 'Label', text: 'Bar' },
   styles: [
     {
       name: 'label-control',
-      classNames: ['jsf-label']
-    }
-  ]
+      classNames: ['jsf-label'],
+    },
+  ],
 };
 
 describe('Label tester', () => {
@@ -60,123 +63,62 @@ describe('Label tester', () => {
 });
 
 describe('Label', () => {
-
   let wrapper: ReactWrapper;
 
   afterEach(() => wrapper.unmount());
 
   test('render with undefined text', () => {
     const uischema: UISchemaElement = { type: 'Label' };
-    const store = initJsonFormsVanillaStore({
-      data: fixture.data,
-      schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
 
-    const label = wrapper.find('label').getDOMNode();
-    expect(label.className).toBe('jsf-label');
+    wrapper = mountForm(uischema);
+
+    const label = wrapper.find('span').getDOMNode();
     expect(label.textContent).toBe('');
   });
 
   test('render with null text', () => {
     const uischema: LabelElement = {
       type: 'Label',
-      text: null
+      text: null,
     };
-    const store = initJsonFormsVanillaStore({
-      data: fixture.data,
-      schema: fixture.schema,
-      uischema,
-      styles: fixture.styles
-    });
 
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={uischema}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
-    const label = wrapper.find('label').getDOMNode();
-    expect(label.className).toBe('jsf-label');
+    wrapper = mountForm(uischema);
+
+    const label = wrapper.find('span').getDOMNode();
     expect(label.textContent).toBe('');
   });
 
   test('render with text', () => {
-    const store = initJsonFormsVanillaStore({
-      data: fixture.data,
-      schema: fixture.schema,
-      uischema: fixture.uischema,
-      styles: fixture.styles
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={fixture.uischema}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
-    const label = wrapper.find('label').getDOMNode();
-    expect(label.className).toBe('jsf-label');
+    wrapper = mountForm(fixture.uischema, fixture.schema, fixture.data);
+
+    const label = wrapper.find('span').getDOMNode();
     expect(label.childNodes).toHaveLength(1);
     expect(label.textContent).toBe('Bar');
   });
 
   test('hide', () => {
-    const store = initJsonFormsVanillaStore({
-      data: fixture.data,
-      schema: fixture.schema,
-      uischema: fixture.uischema
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={fixture.uischema}
-            visible={false}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
-    const label = wrapper.find('label').getDOMNode() as HTMLLabelElement;
+    // Condition that evaluates to false
+    const condition: SchemaBasedCondition = {
+      scope: '',
+      schema: {},
+    };
+
+    const uischema: UISchemaElement = {
+      ...fixture.uischema,
+      rule: {
+        effect: RuleEffect.HIDE,
+        condition,
+      },
+    };
+    wrapper = mountForm(uischema, fixture.schema, fixture.data);
+
+    const label = wrapper.find('div').getDOMNode() as HTMLLabelElement;
     expect(label.hidden).toBe(true);
   });
 
   test('show by default', () => {
-    const store = initJsonFormsVanillaStore({
-      data: fixture.data,
-      schema: fixture.schema,
-      uischema: fixture.uischema
-    });
-    wrapper = mount(
-      <Provider store={store}>
-        <JsonFormsReduxContext>
-          <LabelRenderer
-            schema={fixture.schema}
-            uischema={fixture.uischema}
-          />
-        </JsonFormsReduxContext>
-      </Provider>
-    );
-    const label = wrapper.find('label').getDOMNode() as HTMLLabelElement;
+    wrapper = mountForm(fixture.uischema, fixture.schema, fixture.data);
+    const label = wrapper.find('div').getDOMNode() as HTMLLabelElement;
     expect(label.hidden).toBe(false);
   });
 });

--- a/packages/spectrum/test/renderers/LabelControl.test.tsx
+++ b/packages/spectrum/test/renderers/LabelControl.test.tsx
@@ -28,7 +28,7 @@
 import { LabelElement, RuleEffect, UISchemaElement } from '@jsonforms/core';
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme, { ReactWrapper } from 'enzyme';
-import { labelRendererTester } from '../../src/complex/LabelRenderer';
+import { spectrumLabelRendererTester } from '../../src/complex/SpectrumLabelRenderer';
 import { falseCondition, mountForm } from '../util';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -50,10 +50,10 @@ const fixture = {
 
 describe('Label tester', () => {
   test('tester', () => {
-    expect(labelRendererTester(undefined, undefined)).toBe(-1);
-    expect(labelRendererTester(null, undefined)).toBe(-1);
-    expect(labelRendererTester({ type: 'Foo' }, undefined)).toBe(-1);
-    expect(labelRendererTester({ type: 'Label' }, undefined)).toBe(1);
+    expect(spectrumLabelRendererTester(undefined, undefined)).toBe(-1);
+    expect(spectrumLabelRendererTester(null, undefined)).toBe(-1);
+    expect(spectrumLabelRendererTester({ type: 'Foo' }, undefined)).toBe(-1);
+    expect(spectrumLabelRendererTester({ type: 'Label' }, undefined)).toBe(1);
   });
 });
 

--- a/packages/spectrum/test/renderers/LabelControl.test.tsx
+++ b/packages/spectrum/test/renderers/LabelControl.test.tsx
@@ -25,16 +25,11 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import {
-  LabelElement,
-  RuleEffect,
-  SchemaBasedCondition,
-  UISchemaElement,
-} from '@jsonforms/core';
+import { LabelElement, RuleEffect, UISchemaElement } from '@jsonforms/core';
 import Adapter from 'enzyme-adapter-react-16';
 import Enzyme, { ReactWrapper } from 'enzyme';
 import { labelRendererTester } from '../../src/complex/LabelRenderer';
-import { mountForm } from '../util';
+import { falseCondition, mountForm } from '../util';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -97,17 +92,11 @@ describe('Label', () => {
   });
 
   test('hide', () => {
-    // Condition that evaluates to false
-    const condition: SchemaBasedCondition = {
-      scope: '',
-      schema: {},
-    };
-
     const uischema: UISchemaElement = {
       ...fixture.uischema,
       rule: {
         effect: RuleEffect.HIDE,
-        condition,
+        condition: falseCondition(),
       },
     };
     wrapper = mountForm(uischema, fixture.schema, fixture.data);

--- a/packages/spectrum/test/util.tsx
+++ b/packages/spectrum/test/util.tsx
@@ -27,7 +27,11 @@
 */
 import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
-import { UISchemaElement, JsonSchema } from '@jsonforms/core';
+import {
+  UISchemaElement,
+  JsonSchema,
+  SchemaBasedCondition,
+} from '@jsonforms/core';
 import { JsonForms } from '@jsonforms/react';
 import { vanillaRenderers } from '../src/index';
 
@@ -44,4 +48,11 @@ export function mountForm(
       renderers={vanillaRenderers}
     />
   );
+}
+
+export function falseCondition(): SchemaBasedCondition {
+  return {
+    scope: '',
+    schema: {},
+  };
 }


### PR DESCRIPTION
Migration des LabelRenderers zu react-spectrum, inklusive renaming.

Neue Funktion für tests, die eine Condition liefert, welche zu false evaluiert.