### PR TITLE
include all src and test files in tsconfig

### DIFF
--- a/packages/spectrum/tsconfig.json
+++ b/packages/spectrum/tsconfig.json
@@ -32,7 +32,7 @@
   "exclude":[
     "node_modules"
   ],
-  "files": [
-    "./src/index.ts"
-  ]
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules" ]
+
 }


### PR DESCRIPTION
Intellij did complain about some files not included in tsconfig.json - this caused various other errors in Intellij - especially the import of the react library itself was labelled as an error with a reference to the esModuleInterop flag - which was already set to true.

This change resolves these error messages in Intellij - but I'm not sure about possible unwanted side effects...