### PR TITLE
oneOf #22 & anyOf #23

### DIFF
--- a/packages/spectrum/src/complex/CombinatorProperties.tsx
+++ b/packages/spectrum/src/complex/CombinatorProperties.tsx
@@ -1,22 +1,22 @@
 /*
   The MIT License
-
+  
   Copyright (c) 2017-2019 EclipseSource Munich
   https://github.com/eclipsesource/jsonforms
-
+  
   Copyright (c) 2020 headwire.com, Inc
   https://github.com/headwirecom/jsonforms-react-spectrum-renderers
-
+  
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
   in the Software without restriction, including without limitation the rights
   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
-
+  
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
-
+  
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,34 +25,52 @@
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   THE SOFTWARE.
 */
-import SpectrumObjectRenderer, {
-  spectrumObjectControlTester,
-} from './SpectrumObjectRenderer';
-import ArrayControl, { arrayControlTester } from './array';
-import SpectrumCategorizationRenderer, {
-  spectrumCategorizationRendererTester,
-} from './SpectrumCategorizationRenderer';
-import SpectrumLabelRenderer, {
-  spectrumLabelRendererTester,
-} from './SpectrumLabelRenderer';
-import SpectrumOneOfRenderer, {
-  spectrumOneOfRendererTester,
-} from './SpectrumOneOfRenderer';
-import SpectrumTableArrayControl, {
-  spectrumTableArrayControlTester,
-} from './SpectrumTableArrayControl';
+import React from 'react';
+import { omit } from 'lodash';
+import { Generate, JsonSchema, Layout, UISchemaElement } from '@jsonforms/core';
+import { ResolvedJsonFormsDispatch } from '@jsonforms/react';
 
-export {
-  ArrayControl,
-  arrayControlTester,
-  SpectrumCategorizationRenderer,
-  spectrumCategorizationRendererTester,
-  SpectrumLabelRenderer,
-  spectrumLabelRendererTester,
-  SpectrumObjectRenderer,
-  spectrumObjectControlTester,
-  SpectrumOneOfRenderer,
-  spectrumOneOfRendererTester,
-  SpectrumTableArrayControl,
-  spectrumTableArrayControlTester,
-};
+interface CombinatorPropertiesProps {
+  schema: JsonSchema;
+  combinatorKeyword: 'oneOf' | 'anyOf';
+  path: string;
+}
+
+export const isLayout = (uischema: UISchemaElement): uischema is Layout =>
+  uischema.hasOwnProperty('elements');
+
+export class CombinatorProperties extends React.Component<
+  CombinatorPropertiesProps,
+  {}
+> {
+  render() {
+    const { schema, combinatorKeyword, path } = this.props;
+
+    const otherProps: JsonSchema = omit(
+      schema,
+      combinatorKeyword
+    ) as JsonSchema;
+    const foundUISchema: UISchemaElement = Generate.uiSchema(
+      otherProps,
+      'VerticalLayout'
+    );
+    let isLayoutWithElements = false;
+    if (foundUISchema !== null && isLayout(foundUISchema)) {
+      isLayoutWithElements = foundUISchema.elements.length > 0;
+    }
+
+    if (isLayoutWithElements) {
+      return (
+        <ResolvedJsonFormsDispatch
+          schema={otherProps}
+          path={path}
+          uischema={foundUISchema}
+        />
+      );
+    }
+
+    return null;
+  }
+}
+
+export default CombinatorProperties;

--- a/packages/spectrum/src/complex/SpectrumAnyOfRenderer.tsx
+++ b/packages/spectrum/src/complex/SpectrumAnyOfRenderer.tsx
@@ -1,0 +1,106 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React, { Key, useCallback, useState } from 'react';
+
+import {
+  createCombinatorRenderInfos,
+  isAnyOfControl,
+  JsonSchema,
+  RankedTester,
+  rankWith,
+  resolveSubSchemas,
+  StatePropsOfCombinator,
+} from '@jsonforms/core';
+import {
+  ResolvedJsonFormsDispatch,
+  withJsonFormsAnyOfProps,
+} from '@jsonforms/react';
+import CombinatorProperties from './CombinatorProperties';
+import { Item, View } from '@adobe/react-spectrum';
+import { Tabs } from '@react-spectrum/tabs';
+
+const SpectrumAnyOfRenderer = ({
+  schema,
+  rootSchema,
+  indexOfFittingSchema,
+  visible,
+  path,
+  renderers,
+  cells,
+  uischema,
+  uischemas,
+}: StatePropsOfCombinator) => {
+  const [selectedAnyOf, setSelectedAnyOf] = useState(indexOfFittingSchema || 0);
+  const handleChange = useCallback(
+    (value: Key) => setSelectedAnyOf(Number(value)),
+    [setSelectedAnyOf]
+  );
+  const anyOf = 'anyOf';
+  const _schema = resolveSubSchemas(schema, rootSchema, anyOf);
+  const anyOfRenderInfos = createCombinatorRenderInfos(
+    (_schema as JsonSchema).anyOf,
+    rootSchema,
+    anyOf,
+    uischema,
+    path,
+    uischemas
+  );
+
+  return (
+    <View isHidden={!visible}>
+      <CombinatorProperties
+        schema={_schema}
+        combinatorKeyword={'anyOf'}
+        path={path}
+      />
+      <Tabs
+        selectedKey={String(selectedAnyOf)}
+        onSelectionChange={handleChange}
+      >
+        {anyOfRenderInfos.map((anyOfRenderInfo, anyOfIndex) => (
+          <Item key={anyOfIndex} title={anyOfRenderInfo.label}>
+            <ResolvedJsonFormsDispatch
+              key={anyOfIndex}
+              schema={anyOfRenderInfo.schema}
+              uischema={anyOfRenderInfo.uischema}
+              path={path}
+              renderers={renderers}
+              cells={cells}
+            />
+          </Item>
+        ))}
+      </Tabs>
+    </View>
+  );
+};
+
+export const spectrumAnyOfRendererTester: RankedTester = rankWith(
+  3,
+  isAnyOfControl
+);
+export default withJsonFormsAnyOfProps(SpectrumAnyOfRenderer);

--- a/packages/spectrum/src/complex/SpectrumOneOfRenderer.tsx
+++ b/packages/spectrum/src/complex/SpectrumOneOfRenderer.tsx
@@ -1,0 +1,178 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+  
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React, { Key, useCallback, useState } from 'react';
+import isEmpty from 'lodash/isEmpty';
+
+import {
+  CombinatorProps,
+  createCombinatorRenderInfos,
+  createDefaultValue,
+  isOneOfControl,
+  JsonSchema,
+  OwnPropsOfControl,
+  RankedTester,
+  rankWith,
+  resolveSubSchemas,
+} from '@jsonforms/core';
+import {
+  ResolvedJsonFormsDispatch,
+  withJsonFormsOneOfProps,
+} from '@jsonforms/react';
+import CombinatorProperties from './CombinatorProperties';
+import {
+  Button,
+  ButtonGroup,
+  Content,
+  Dialog,
+  DialogContainer,
+  Divider,
+  Heading,
+  Item,
+  View,
+} from '@adobe/react-spectrum';
+import { Tabs } from '@react-spectrum/tabs';
+
+export interface OwnOneOfProps extends OwnPropsOfControl {
+  indexOfFittingSchema?: number;
+}
+
+const oneOf = 'oneOf';
+const SpectrumOneOfRenderer = ({
+  handleChange,
+  schema,
+  path,
+  renderers,
+  cells,
+  rootSchema,
+  id,
+  visible,
+  indexOfFittingSchema,
+  uischema,
+  uischemas,
+  data,
+}: CombinatorProps) => {
+  const [open, setOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(indexOfFittingSchema || 0);
+  const [newSelectedIndex, setNewSelectedIndex] = useState(0);
+  const handleClose = useCallback(() => setOpen(false), [setOpen]);
+  const cancel = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+  const _schema = resolveSubSchemas(schema, rootSchema, oneOf);
+  const oneOfRenderInfos = createCombinatorRenderInfos(
+    (_schema as JsonSchema).oneOf,
+    rootSchema,
+    oneOf,
+    uischema,
+    path,
+    uischemas
+  );
+
+  const openNewTab = (newIndex: number) => {
+    handleChange(path, createDefaultValue(schema.oneOf[newIndex]));
+    setSelectedIndex(newIndex);
+  };
+
+  const confirm = useCallback(() => {
+    openNewTab(newSelectedIndex);
+    setOpen(false);
+  }, [handleChange, createDefaultValue, newSelectedIndex]);
+
+  const handleTabChange = useCallback(
+    (newOneOfIndex: Key) => {
+      newOneOfIndex = Number(newOneOfIndex);
+      setNewSelectedIndex(newOneOfIndex);
+      if (isEmpty(data)) {
+        openNewTab(newOneOfIndex);
+      } else {
+        setOpen(true);
+      }
+    },
+    [setOpen, setSelectedIndex, data]
+  );
+
+  return (
+    <View isHidden={!visible}>
+      <CombinatorProperties
+        schema={_schema}
+        combinatorKeyword={'oneOf'}
+        path={path}
+      />
+      <Tabs
+        selectedKey={String(selectedIndex)}
+        onSelectionChange={handleTabChange}
+      >
+        {oneOfRenderInfos.map((oneOfRenderInfo, oneOfIndex) => (
+          <Item key={oneOfIndex} title={oneOfRenderInfo.label}>
+            <Content margin='size-160'>
+              <ResolvedJsonFormsDispatch
+                key={oneOfIndex}
+                schema={oneOfRenderInfo.schema}
+                uischema={oneOfRenderInfo.uischema}
+                path={path}
+                renderers={renderers}
+                cells={cells}
+              />
+            </Content>
+          </Item>
+        ))}
+      </Tabs>
+      <DialogContainer onDismiss={handleClose}>
+        {open && (
+          <Dialog>
+            <Heading>Clear form?</Heading>
+            <Divider />
+            <Content>
+              Your data will be cleared if you navigate away from this tab. Do
+              you want to proceed?
+            </Content>
+            <ButtonGroup>
+              <Button variant='secondary' onPress={cancel}>
+                Cancel
+              </Button>
+              <Button
+                variant='cta'
+                onPress={confirm}
+                autoFocus
+                id={`oneOf-${id}-confirm-yes`}
+              >
+                Confirm
+              </Button>
+            </ButtonGroup>
+          </Dialog>
+        )}
+      </DialogContainer>
+    </View>
+  );
+};
+
+export const spectrumOneOfRendererTester: RankedTester = rankWith(
+  3,
+  isOneOfControl
+);
+export default withJsonFormsOneOfProps(SpectrumOneOfRenderer);

--- a/packages/spectrum/src/complex/index.ts
+++ b/packages/spectrum/src/complex/index.ts
@@ -29,6 +29,9 @@ import SpectrumObjectRenderer, {
   spectrumObjectControlTester,
 } from './SpectrumObjectRenderer';
 import ArrayControl, { arrayControlTester } from './array';
+import SpectrumAnyOfRenderer, {
+  spectrumAnyOfRendererTester,
+} from './SpectrumAnyOfRenderer';
 import SpectrumCategorizationRenderer, {
   spectrumCategorizationRendererTester,
 } from './SpectrumCategorizationRenderer';
@@ -45,6 +48,8 @@ import SpectrumTableArrayControl, {
 export {
   ArrayControl,
   arrayControlTester,
+  SpectrumAnyOfRenderer,
+  spectrumAnyOfRendererTester,
   SpectrumCategorizationRenderer,
   spectrumCategorizationRendererTester,
   SpectrumLabelRenderer,

--- a/packages/spectrum/src/index.ts
+++ b/packages/spectrum/src/index.ts
@@ -69,6 +69,8 @@ import {
 import {
   ArrayControl,
   arrayControlTester,
+  SpectrumAnyOfRenderer,
+  spectrumAnyOfRendererTester,
   SpectrumCategorizationRenderer,
   spectrumCategorizationRendererTester,
   SpectrumLabelRenderer,
@@ -118,6 +120,10 @@ export const spectrumRenderers: { tester: RankedTester; renderer: any }[] = [
   {
     tester: spectrumOneOfRendererTester,
     renderer: SpectrumOneOfRenderer,
+  },
+  {
+    tester: spectrumAnyOfRendererTester,
+    renderer: SpectrumAnyOfRenderer,
   },
   {
     tester: spectrumTableArrayControlTester,

--- a/packages/spectrum/src/index.ts
+++ b/packages/spectrum/src/index.ts
@@ -75,6 +75,8 @@ import {
   spectrumLabelRendererTester,
   spectrumObjectControlTester,
   SpectrumObjectRenderer,
+  SpectrumOneOfRenderer,
+  spectrumOneOfRendererTester,
   SpectrumTableArrayControl,
   spectrumTableArrayControlTester,
 } from './complex';
@@ -113,6 +115,10 @@ export const spectrumRenderers: { tester: RankedTester; renderer: any }[] = [
     renderer: SpectrumCategorizationRenderer,
   },
   { tester: spectrumObjectControlTester, renderer: SpectrumObjectRenderer },
+  {
+    tester: spectrumOneOfRendererTester,
+    renderer: SpectrumOneOfRenderer,
+  },
   {
     tester: spectrumTableArrayControlTester,
     renderer: SpectrumTableArrayControl,

--- a/packages/spectrum/test/renderers/SpectrumAnyOfRenderer.test.tsx
+++ b/packages/spectrum/test/renderers/SpectrumAnyOfRenderer.test.tsx
@@ -29,7 +29,9 @@
 import Enzyme, { ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import {
-  ControlElement, RuleEffect, SchemaBasedCondition,
+  ControlElement,
+  RuleEffect,
+  SchemaBasedCondition,
 } from '@jsonforms/core';
 import { Tab } from '@react-spectrum/tabs';
 import { mountForm } from '../util';
@@ -37,7 +39,7 @@ import { SpectrumAnyOfRenderer } from '../../src';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+const waitForAsync = () => new Promise((resolve) => setImmediate(resolve));
 
 const clickAddButton = (wrapper: ReactWrapper, times: number) => {
   const buttons = wrapper.find('button');
@@ -54,13 +56,13 @@ const selectanyOfTab = (wrapper: ReactWrapper, at: number) => {
   wrapper.update();
 };
 
-describe('Material anyOf renderer', () => {
+describe('Spectrum anyOf renderer', () => {
   let wrapper: ReactWrapper;
 
   afterEach(() => wrapper.unmount());
 
   it('should add an item at correct path', () => {
-    let state: any = undefined
+    let state: any = undefined;
     const schema = {
       type: 'object',
       properties: {
@@ -68,28 +70,34 @@ describe('Material anyOf renderer', () => {
           anyOf: [
             {
               title: 'String',
-              type: 'string'
+              type: 'string',
             },
             {
               title: 'Number',
-              type: 'number'
-            }
-          ]
-        }
-      }
+              type: 'number',
+            },
+          ],
+        },
+      },
     };
     const uischema: ControlElement = {
       type: 'Control',
       label: 'Value',
-      scope: '#/properties/value'
+      scope: '#/properties/value',
     };
-    wrapper = mountForm(uischema, schema, undefined, undefined, ({data}) => state = data)
+    wrapper = mountForm(
+      uischema,
+      schema,
+      undefined,
+      undefined,
+      ({ data }) => (state = data)
+    );
 
     const input = wrapper.find('input').first();
     input.simulate('change', { target: { value: 'test' } });
     wrapper.update();
     expect(state).toEqual({
-      value: 'test'
+      value: 'test',
     });
   });
 
@@ -101,13 +109,13 @@ describe('Material anyOf renderer', () => {
         myThingsAndOrYourThings: {
           anyOf: [
             {
-              $ref: '#/definitions/myThings'
+              $ref: '#/definitions/myThings',
             },
             {
-              $ref: '#/definitions/yourThings'
-            }
-          ]
-        }
+              $ref: '#/definitions/yourThings',
+            },
+          ],
+        },
       },
       definitions: {
         myThings: {
@@ -117,10 +125,10 @@ describe('Material anyOf renderer', () => {
             type: 'object',
             properties: {
               name: {
-                type: 'string'
-              }
-            }
-          }
+                type: 'string',
+              },
+            },
+          },
         },
         yourThings: {
           title: 'YourThings',
@@ -129,19 +137,19 @@ describe('Material anyOf renderer', () => {
             type: 'object',
             properties: {
               age: {
-                type: 'number'
-              }
-            }
-          }
-        }
-      }
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
     };
     const uischema: ControlElement = {
       type: 'Control',
-      scope: '#/properties/myThingsAndOrYourThings'
+      scope: '#/properties/myThingsAndOrYourThings',
     };
 
-    wrapper = mountForm(uischema, schema, {})
+    wrapper = mountForm(uischema, schema, {});
 
     await waitForAsync();
 
@@ -167,13 +175,13 @@ describe('Material anyOf renderer', () => {
         myThingsAndOrYourThings: {
           anyOf: [
             {
-              $ref: '#/definitions/myThings'
+              $ref: '#/definitions/myThings',
             },
             {
-              $ref: '#/definitions/yourThings'
-            }
-          ]
-        }
+              $ref: '#/definitions/yourThings',
+            },
+          ],
+        },
       },
       definitions: {
         myThings: {
@@ -183,10 +191,10 @@ describe('Material anyOf renderer', () => {
             type: 'object',
             properties: {
               name: {
-                type: 'string'
-              }
-            }
-          }
+                type: 'string',
+              },
+            },
+          },
         },
         yourThings: {
           title: 'YourThings',
@@ -195,20 +203,25 @@ describe('Material anyOf renderer', () => {
             type: 'object',
             properties: {
               age: {
-                type: 'number'
-              }
-            }
-          }
-        }
-      }
+                type: 'number',
+              },
+            },
+          },
+        },
+      },
     };
     const uischema: ControlElement = {
       type: 'Control',
-      scope: '#/properties/myThingsAndOrYourThings'
+      scope: '#/properties/myThingsAndOrYourThings',
     };
 
-
-    wrapper = mountForm(uischema, schema, {}, undefined, ({data}) => state = data);
+    wrapper = mountForm(
+      uischema,
+      schema,
+      {},
+      undefined,
+      ({ data }) => (state = data)
+    );
 
     await waitForAsync();
 
@@ -228,7 +241,7 @@ describe('Material anyOf renderer', () => {
     wrapper.update();
 
     expect(state).toEqual({
-      myThingsAndOrYourThings: [{ age: 5, name: 'test' }]
+      myThingsAndOrYourThings: [{ age: 5, name: 'test' }],
     });
   });
 
@@ -244,15 +257,15 @@ describe('Material anyOf renderer', () => {
           anyOf: [
             {
               title: 'String',
-              type: 'string'
+              type: 'string',
             },
             {
               title: 'Number',
-              type: 'number'
-            }
-          ]
-        }
-      }
+              type: 'number',
+            },
+          ],
+        },
+      },
     };
     const uischema: ControlElement = {
       type: 'Control',
@@ -264,7 +277,7 @@ describe('Material anyOf renderer', () => {
       },
     };
 
-    wrapper = mountForm(uischema, schema)
+    wrapper = mountForm(uischema, schema);
 
     const renderer = wrapper
       .find(SpectrumAnyOfRenderer)

--- a/packages/spectrum/test/renderers/SpectrumAnyOfRenderer.test.tsx
+++ b/packages/spectrum/test/renderers/SpectrumAnyOfRenderer.test.tsx
@@ -1,0 +1,274 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import Enzyme, { ReactWrapper } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  ControlElement, RuleEffect, SchemaBasedCondition,
+} from '@jsonforms/core';
+import { Tab } from '@react-spectrum/tabs';
+import { mountForm } from '../util';
+import { SpectrumAnyOfRenderer } from '../../src';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+
+const clickAddButton = (wrapper: ReactWrapper, times: number) => {
+  const buttons = wrapper.find('button');
+  const addButton = buttons.first();
+  for (let i = 0; i < times; i++) {
+    addButton.simulate('click');
+  }
+  wrapper.update();
+};
+
+const selectanyOfTab = (wrapper: ReactWrapper, at: number) => {
+  const buttons = wrapper.find(Tab);
+  buttons.at(at).simulate('click'); // TODO: how to select Spectrum tab?
+  wrapper.update();
+};
+
+describe('Material anyOf renderer', () => {
+  let wrapper: ReactWrapper;
+
+  afterEach(() => wrapper.unmount());
+
+  it('should add an item at correct path', () => {
+    let state: any = undefined
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+    wrapper = mountForm(uischema, schema, undefined, undefined, ({data}) => state = data)
+
+    const input = wrapper.find('input').first();
+    input.simulate('change', { target: { value: 'test' } });
+    wrapper.update();
+    expect(state).toEqual({
+      value: 'test'
+    });
+  });
+
+  // TODO: how to select Spectrum tab in selectanyOfTab?
+  it.skip('should add a "mything"', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        myThingsAndOrYourThings: {
+          anyOf: [
+            {
+              $ref: '#/definitions/myThings'
+            },
+            {
+              $ref: '#/definitions/yourThings'
+            }
+          ]
+        }
+      },
+      definitions: {
+        myThings: {
+          title: 'MyThing',
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        yourThings: {
+          title: 'YourThings',
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              age: {
+                type: 'number'
+              }
+            }
+          }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/myThingsAndOrYourThings'
+    };
+
+    wrapper = mountForm(uischema, schema, {})
+
+    await waitForAsync();
+
+    wrapper.update();
+
+    selectanyOfTab(wrapper, 1);
+    const nrOfRowsBeforeAdd = wrapper.find('tr');
+    clickAddButton(wrapper, 2);
+    const nrOfRowsAfterAdd = wrapper.find('tr');
+
+    // 2 header row + 1 no data row
+    expect(nrOfRowsBeforeAdd.length).toBe(3);
+    // 2 header row + 2 data rows (one is replacing the 'No data' one)
+    expect(nrOfRowsAfterAdd.length).toBe(4);
+  });
+
+  // TODO: how to select Spectrum tab in selectanyOfTab?
+  it.skip('should switch to "yourThing" edit, then switch back, then edit', async () => {
+    let state: any = {};
+    const schema = {
+      type: 'object',
+      properties: {
+        myThingsAndOrYourThings: {
+          anyOf: [
+            {
+              $ref: '#/definitions/myThings'
+            },
+            {
+              $ref: '#/definitions/yourThings'
+            }
+          ]
+        }
+      },
+      definitions: {
+        myThings: {
+          title: 'MyThing',
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        yourThings: {
+          title: 'YourThings',
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              age: {
+                type: 'number'
+              }
+            }
+          }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/myThingsAndOrYourThings'
+    };
+
+
+    wrapper = mountForm(uischema, schema, {}, undefined, ({data}) => state = data);
+
+    await waitForAsync();
+
+    wrapper.update();
+
+    selectanyOfTab(wrapper, 1);
+    clickAddButton(wrapper, 1);
+    wrapper
+      .find('input')
+      .first()
+      .simulate('change', { target: { value: 5 } });
+    wrapper.update();
+    selectanyOfTab(wrapper, 0);
+
+    const input = wrapper.find('input').first();
+    input.simulate('change', { target: { value: 'test' } });
+    wrapper.update();
+
+    expect(state).toEqual({
+      myThingsAndOrYourThings: [{ age: 5, name: 'test' }]
+    });
+  });
+
+  it('should be hideable', () => {
+    const condition: SchemaBasedCondition = {
+      scope: '',
+      schema: {},
+    };
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value',
+      rule: {
+        effect: RuleEffect.HIDE,
+        condition,
+      },
+    };
+
+    wrapper = mountForm(uischema, schema)
+
+    const renderer = wrapper
+      .find(SpectrumAnyOfRenderer)
+      .getDOMNode() as HTMLElement;
+    expect(renderer.style.display).toBe('none');
+  });
+});

--- a/packages/spectrum/test/renderers/SpectrumOneOfRenderer.test.tsx
+++ b/packages/spectrum/test/renderers/SpectrumOneOfRenderer.test.tsx
@@ -1,0 +1,505 @@
+/*
+  The MIT License
+  
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+  
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+import Enzyme, { ReactWrapper } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import {
+  ControlElement, RuleEffect, SchemaBasedCondition,
+} from '@jsonforms/core';
+import { mountForm } from '../util';
+import { Tab } from '@react-spectrum/tabs';
+import { Dialog } from '@adobe/react-spectrum';
+import { SpectrumOneOfRenderer } from '../../src';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+const waitForAsync = () => new Promise(resolve => setImmediate(resolve));
+
+const clickAddButton = (wrapper: ReactWrapper, times: number) => {
+  // click add button
+  const buttons = wrapper.find('button');
+  const addButton = buttons.first();
+  for (let i = 0; i < times; i++) {
+    addButton.simulate('click');
+  }
+  wrapper.update();
+};
+
+const selectOneOfTab = (
+  wrapper: ReactWrapper,
+  at: number,
+  expectConfim: boolean
+) => {
+  // select oneOf
+  const tabs = wrapper.find(Tab);
+  tabs.at(at).simulate('click'); // TODO: how to select Spectrum tab?
+  wrapper.update();
+
+  if (expectConfim) {
+    // confirm dialog
+    console.log(wrapper.find(Dialog).length)
+    const confirmButton = wrapper
+      .find(Dialog)
+      .find('button')
+      .at(1);
+    confirmButton.simulate('click');
+    wrapper.update();
+  } else {
+    expect(
+      wrapper
+        .find(Dialog)
+        .find('button')
+        .at(1)
+        .exists()
+    ).toBe(false);
+  }
+};
+
+describe('Spectrum oneOf renderer', () => {
+  let wrapper: ReactWrapper;
+
+  afterEach(() => wrapper.unmount());
+
+  it('should render and select first tab by default', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+
+    wrapper = mountForm(uischema, schema);
+    
+    const firstTab =wrapper.find(Tab).first()
+    expect(firstTab.getDOMNode().className).toContain('is-selected')
+  });
+  
+  it('should render and select second tab due to datatype', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+
+    wrapper = mountForm(uischema, schema, { value: 5 });
+
+    const secondTab = wrapper.find(Tab).at(1);
+    expect(secondTab.getDOMNode().className).toContain('is-selected')
+  });
+  
+  it('should render and select second tab due to schema with additionalProperties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'object',
+              properties: {
+                foo: { type: 'string' }
+              },
+              additionalProperties: false
+            },
+            {
+              title: 'Number',
+              type: 'object',
+              properties: {
+                bar: { type: 'string' }
+              },
+              additionalProperties: false
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+    
+    wrapper = mountForm(uischema, schema, { value: { bar: 'bar' } });
+
+    const secondTab = wrapper.find(Tab).at(1);
+    expect(secondTab.getDOMNode().className).toContain('is-selected')
+  });
+  
+  it('should render and select second tab due to schema with required', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'object',
+              properties: {
+                foo: { type: 'string' }
+              },
+              required: ['foo']
+            },
+            {
+              title: 'Number',
+              type: 'object',
+              properties: {
+                bar: { type: 'string' }
+              },
+              required: ['bar']
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+
+    wrapper = mountForm(uischema, schema, { value: { bar: 'bar' } });
+    
+    const secondTab = wrapper.find(Tab).at(1);
+    expect(secondTab.getDOMNode().className).toContain('is-selected')
+  });
+
+  it('should add an item at correct path', () => {
+    let state = {}
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+    
+    wrapper = mountForm(uischema, schema, undefined, undefined, ({data}) => state = data);
+    
+    const input = wrapper.find('input').first();
+    input.simulate('change', { target: { value: 'test' } });
+    wrapper.update();
+    expect(state).toEqual({
+      value: 'test'
+    });
+  });
+
+  // TODO: how to select Spectrum tab in selectOneOfTab?
+  it.skip('should add an item within an array', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        thingOrThings: {
+          oneOf: [
+            {
+              $ref: '#/definitions/thing'
+            },
+            {
+              $ref: '#/definitions/thingArray'
+            }
+          ]
+        }
+      },
+      definitions: {
+        thing: {
+          title: 'Thing',
+          type: 'string'
+        },
+        thingArray: {
+          title: 'Things',
+          type: 'array',
+          items: {
+            $ref: '#/definitions/thing'
+          }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/thingOrThings'
+    };
+
+    wrapper = mountForm(uischema, schema, {});
+
+    await waitForAsync();
+
+    wrapper.update();
+
+    selectOneOfTab(wrapper, 1, false);
+    const nrOfRowsBeforeAdd = wrapper.find('tr');
+    clickAddButton(wrapper, 2);
+    const nrOfRowsAfterAdd = wrapper.find('tr');
+
+    // 1 header row + no data row
+    expect(nrOfRowsBeforeAdd.length).toBe(2);
+    // 1 header row + 2 data rows (one is replacing the 'No data' one)
+    expect(nrOfRowsAfterAdd.length).toBe(3);
+  });
+
+  // TODO: how to select Spectrum tab in selectOneOfTab?
+  it.skip('should add an object within an array', async () => {
+    let state: any = {}
+    const schema = {
+      type: 'object',
+      properties: {
+        thingOrThings: {
+          oneOf: [
+            {
+              title: 'Thing',
+              type: 'object',
+              properties: {
+                thing: {
+                  $ref: '#/definitions/thing'
+                }
+              }
+            },
+            {
+              $ref: '#/definitions/thingArray'
+            }
+          ]
+        }
+      },
+      definitions: {
+        thing: {
+          title: 'Thing',
+          type: 'string'
+        },
+        thingArray: {
+          title: 'Things',
+          type: 'array',
+          items: {
+            $ref: '#/definitions/thing'
+          }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/thingOrThings'
+    };
+
+    wrapper = mountForm(uischema, schema, {}, undefined, ({data}) => state = data)
+
+    await waitForAsync();
+
+    // expect(wrapper.state())
+    wrapper.update();
+
+    selectOneOfTab(wrapper, 1, false);
+    const nrOfRowsBeforeAdd = wrapper.find('tr');
+    clickAddButton(wrapper, 2);
+    const nrOfRowsAfterAdd = wrapper.find('tr');
+
+    // 1 header row + no data row
+    expect(nrOfRowsBeforeAdd.length).toBe(2);
+    // 1 header row + 2 data rows (one is replacing the 'No data' one)
+    expect(nrOfRowsAfterAdd.length).toBe(3);
+    expect(state).toEqual({
+      thingOrThings: ['', '']
+    });
+  });
+
+  // TODO: how to select Spectrum tab in selectOneOfTab?
+  it.skip('should switch to array based oneOf subschema, then switch back, then edit', async () => {
+    let state: any = {}
+    const schema = {
+      type: 'object',
+      properties: {
+        thingOrThings: {
+          oneOf: [
+            {
+              title: 'Thing',
+              type: 'object',
+              properties: {
+                thing: {
+                  $ref: '#/definitions/thing'
+                }
+              }
+            },
+            {
+              $ref: '#/definitions/thingArray'
+            }
+          ]
+        }
+      },
+      definitions: {
+        thing: {
+          title: 'Thing',
+          type: 'string'
+        },
+        thingArray: {
+          title: 'Things',
+          type: 'array',
+          items: {
+            $ref: '#/definitions/thing'
+          }
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      scope: '#/properties/thingOrThings'
+    };
+
+    wrapper = mountForm(uischema, schema, {}, undefined, ({data}) => state = data)
+
+    await waitForAsync();
+
+    wrapper.update();
+
+    selectOneOfTab(wrapper, 1, false);
+    clickAddButton(wrapper, 2);
+    selectOneOfTab(wrapper, 0, true);
+
+    const input = wrapper.find('input').first();
+    input.simulate('change', { target: { value: 'test' } });
+    wrapper.update();
+    expect(state).toEqual({
+      thingOrThings: { thing: 'test' }
+    });
+  });
+
+  // TODO: how to select Spectrum tab in selectOneOfTab?
+  it.skip('should show confirm dialog when data is not an empty object', async () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value'
+    };
+
+    wrapper = mountForm(uischema, schema, { value: 'Foo Bar' })
+
+    await waitForAsync();
+    wrapper.update();
+    selectOneOfTab(wrapper, 1, true);
+  });
+
+  it('should be hideable', () => {
+    const condition: SchemaBasedCondition = {
+      scope: '',
+      schema: {},
+    };
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            {
+              title: 'String',
+              type: 'string'
+            },
+            {
+              title: 'Number',
+              type: 'number'
+            }
+          ]
+        }
+      }
+    };
+    const uischema: ControlElement = {
+      type: 'Control',
+      label: 'Value',
+      scope: '#/properties/value',
+      rule: {
+        effect: RuleEffect.HIDE,
+        condition,
+      },
+    };
+
+    wrapper = mountForm(uischema, schema)
+    const renderer = wrapper
+      .find(SpectrumOneOfRenderer)
+      .getDOMNode() as HTMLElement;
+    expect(renderer.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
Implemented the oneOf and anyOf renderers just as in the Material renderer set.

- Since we yet don't have any approach of how to click on tabs in the Enzyme tests, I had to skip some tests where this is necessary.
- There is also the https://github.com/eclipsesource/jsonforms/blob/08c6b93fe355d454c97bc8e821382a4b08318ab9/packages/material/src/controls/MaterialAnyOfStringOrEnumControl.tsx#L102 renderer, which covers the "AnyOf Simple" example. Maybe this should also be included?