### PR TITLE
#34: cleanup of example project

### DIFF
--- a/packages/example/src/App.css
+++ b/packages/example/src/App.css
@@ -4,7 +4,6 @@
 
 .App-logo {
   animation: App-logo-spin infinite 20s linear;
-  height: 80px;
 }
 
 .App-header {
@@ -14,17 +13,53 @@
   color: white;
 }
 
+.container {
+  display: flex; /* or inline-flex */
+  flex-flow: row nowrap;
+}
+
+.container > * {
+  flex: 1 100%;
+}
+
+.App-header ul > li {
+  display: inline-block;
+  width: 9em;
+  font-size: 1.1em;
+}
+
 .App-title {
-  font-size: 1.5em;
+  font-size: 1.1em;
+}
+
+.App-header > h1 {
+  margin-block-start: 0px;
 }
 
 .App-intro {
   font-size: large;
 }
 
+.App-Form {
+  flex: 8 0px;
+  padding-top: 1em;
+}
+
+.App-selection {
+  flex: 1 auto;
+}
+
+.App-Data {
+  flex: 2 auto;
+}
+
 @keyframes App-logo-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .data-title {
@@ -37,7 +72,50 @@
   justify-content: center;
 }
 
+.data-content > pre {
+  width: 100%;
+}
+
 .demoform {
   width: 80%;
   margin: auto;
+}
+
+.tabs {
+  position: relative;
+  min-height: 200px; /* This part sucks */
+  clear: both;
+  margin: 25px 0;
+}
+.tab {
+  float: left;
+}
+.tab label {
+  background: #eee;
+  padding: 10px;
+  border: 1px solid #ccc;
+  margin-left: -1px;
+  position: relative;
+  left: 1px;
+}
+.tab [type='radio'] {
+  display: none;
+}
+.content {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  background: white;
+  right: 0;
+  bottom: 0;
+  padding: 20px;
+  border: 1px solid #ccc;
+}
+[type='radio']:checked ~ label {
+  background: white;
+  border-bottom: 1px solid white;
+  z-index: 2;
+}
+[type='radio']:checked ~ label ~ .content {
+  z-index: 1;
 }

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -32,50 +32,121 @@ import './App.css';
 import { AppProps, initializedConnect } from './reduxUtil';
 
 const preStyle: CSSProperties = {
-  overflowX: 'auto'
+  overflowX: 'auto',
 };
 class App extends Component<AppProps> {
   render() {
     return (
       <JsonFormsReduxContext>
-          <div>
-            <div className='App'>
-              <header className='App-header'>
-                <img src='assets/logo.svg' className='App-logo' alt='logo' />
-                <h1 className='App-title'>Welcome to JSON Forms with React</h1>
-                <p className='App-intro'>More Forms. Less Code.</p>
-              </header>
-            </div>
+        <div className='Shell'>
+          <div className='App'>
+            <header className='App-header'>
+              <ul>
+                <li>
+                  <img src='assets/logo.svg' className='App-logo' alt='logo' />
+                </li>
+                <li>
+                  <h1>React Spectrum</h1>
+                </li>
+                <li>
+                  <h1>JSON Forms</h1>
+                </li>
+              </ul>
+              <p className='App-intro'>More Forms. Less Code.</p>
+            </header>
+          </div>
 
-            <h4 className='data-title'>Examples</h4>
-            <div className='data-content'>
-              <select
-                value={this.props.selectedExample.name || ''}
-                onChange={ev =>
-                  this.props.changeExample(ev.currentTarget.value)
-                }
-              >
-                {this.props.examples.map(optionValue => (
-                  <option
-                    value={optionValue.name}
-                    label={optionValue.label}
-                    key={optionValue.name}
-                  >
-                    {optionValue.label}
+          <div className='container'>
+            <div className='App-selection'>
+              <h4 className='data-title'>JsonForms Examples</h4>
+              <div className='data-content'>
+                <select
+                  value={this.props.selectedExample.name || ''}
+                  onChange={(ev) =>
+                    this.props.changeExample(ev.currentTarget.value)
+                  }
+                >
+                  <option value='-' disabled>
+                    ---- react spectrum tests ----
                   </option>
-                ))}
-              </select>
+                  {this.props.examples
+                    .filter((optionValue) =>
+                      optionValue.name.startsWith('spectrum-')
+                    )
+                    .map((optionValue) => (
+                      <option
+                        value={optionValue.name}
+                        label={optionValue.label}
+                        key={optionValue.name}
+                      >
+                        {optionValue.label}
+                      </option>
+                    ))}
+                  <option value='-' disabled>
+                    ---- jsonforms tests ----
+                  </option>
+                  {this.props.examples
+                    .filter(
+                      (optionValue) => !optionValue.name.startsWith('spectrum-')
+                    )
+                    .map((optionValue) => (
+                      <option
+                        value={optionValue.name}
+                        label={optionValue.label}
+                        key={optionValue.name}
+                      >
+                        {optionValue.label}
+                      </option>
+                    ))}
+                </select>
+              </div>
             </div>
 
-            <h4 className='data-title'>Bound data</h4>
-            <div className='data-content'>
-              <pre style={preStyle}>{this.props.dataAsString}</pre>
+            <div className='App-Form'>
+              <div className='demoform'>
+                {this.props.getExtensionComponent()}
+                <JsonFormsDispatch onChange={this.props.onChange} />
+              </div>
             </div>
-            <div className='demoform'>
-              {this.props.getExtensionComponent()}
-              <JsonFormsDispatch onChange={this.props.onChange} />
+
+            <div className='App-Data tabs'>
+              <div className='tab'>
+                <input
+                  type='radio'
+                  id='tab-1'
+                  name='tab-group-1'
+                  defaultChecked
+                />
+                <label htmlFor='tab-1'>Bound data</label>
+                <div className='data-content content'>
+                  <pre style={preStyle}>{this.props.dataAsString}</pre>
+                </div>
+              </div>
+              <div className='tab'>
+                <input type='radio' id='tab-2' name='tab-group-1' />
+                <label htmlFor='tab-2'>UI Schema</label>
+                <div className='data-content content'>
+                  <pre style={preStyle}>
+                    {JSON.stringify(
+                      this.props.selectedExample.uischema,
+                      null,
+                      2
+                    )}
+                  </pre>
+                </div>
+              </div>
+              <div className='tab'>
+                <input type='radio' id='tab-3' name='tab-group-1' />
+                <label htmlFor='tab-3'>Schema</label>
+                <div className='data-content content'>
+                  <pre style={preStyle}>
+                    {JSON.stringify(this.props.selectedExample.schema, null, 2)}
+                  </pre>
+                </div>
+              </div>
             </div>
           </div>
+        </div>
       </JsonFormsReduxContext>
     );
   }

--- a/packages/example/src/index.tsx
+++ b/packages/example/src/index.tsx
@@ -40,7 +40,7 @@ import {
   JsonFormsRendererRegistryEntry,
   RankedTester,
 } from '@jsonforms/core';
-import { getExamples } from '@jsonforms/examples';
+import { getExamples, registerExamples } from '@jsonforms/examples';
 import { AdditionalStoreParams, exampleReducer } from './reduxUtil';
 import { enhanceExample, ReactExampleDescription } from './util';
 
@@ -48,6 +48,21 @@ import {
   defaultTheme,
   Provider as SpectrumThemeProvider,
 } from '@adobe/react-spectrum';
+
+const getExampleSchemas = () => {
+  registerExamples([
+    {
+      name: 'spectrum-test',
+      label: 'test',
+      data: { name: 'a sample name' },
+      schema: undefined,
+      uischema: undefined,
+    },
+  ]);
+
+  const examples = getExamples();
+  return examples;
+};
 
 const setupStore = (
   exampleData: ReactExampleDescription[],
@@ -126,7 +141,7 @@ export const renderExample = (
   enhancer?: (examples: ReactExampleDescription[]) => ReactExampleDescription[],
   ...additionalStoreParams: AdditionalStoreParams[]
 ) => {
-  const exampleData = enhanceExample(getExamples());
+  const exampleData = enhanceExample(getExampleSchemas());
   const enhancedExampleData = enhancer ? enhancer(exampleData) : exampleData;
   const store = setupStore(
     enhancedExampleData,

--- a/packages/spectrum/example/index.html
+++ b/packages/spectrum/example/index.html
@@ -1,27 +1,25 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="utf-8" />
+    <title>React - React Spectrum - JsonForms - samples</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="assets/example.css" />
+    <link rel="stylesheet" href="assets/example.dark.css" />
+    <style type="text/css">
+      #theme {
+        position: absolute;
+        color: whitesmoke;
+        top: 0.25em;
+        left: 0.25em;
+      }
+    </style>
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <title>ReactiveForms Default RendererSet</title>
-  <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="assets/example.css">
-  <link rel="stylesheet" href="assets/example.dark.css">
-  <style type="text/css">
-    #theme {
-      position: absolute;
-      color: whitesmoke;
-      top: 0.25em;
-      left: 0.25em;
-    }
-  </style>
-</head>
-
-<body>
-  <div id="theme"></div>
-  <div id="root"></div>
-</body>
-<script src="assets/bundle.js"></script>
-
+  <body>
+    <div id="theme"></div>
+    <div id="root"></div>
+  </body>
+  <script src="assets/bundle.js"></script>
 </html>


### PR DESCRIPTION
I did a bit of a cleanup for the example project. While it seems to be ok my css/ts skills are not the best :-) 

things I did for this:
- example selection, form, data is now presented as a row (flexbox)
- index.tsx in packages/example/src now allows us to add our own examples at the top of the list (probably could use a better way to create examples)
- data, schema and uischema are now rendered on the page (tabs)