### PR TITLE
Fix disabling of children in layouts

### DIFF
--- a/packages/spectrum/src/layouts/SpectrumGroupLayout.tsx
+++ b/packages/spectrum/src/layouts/SpectrumGroupLayout.tsx
@@ -53,6 +53,7 @@ export const SpectrumGroupLayoutRenderer: FunctionComponent<RendererProps> = ({
   uischema,
   path,
   visible,
+  enabled,
 }: RendererProps) => {
   const group = uischema as GroupLayout;
 
@@ -76,7 +77,7 @@ export const SpectrumGroupLayoutRenderer: FunctionComponent<RendererProps> = ({
       ) : (
         ''
       )}
-      <Content>{renderChildren(group, schema, {}, path)}</Content>
+      <Content>{renderChildren(group, schema, {}, path, enabled)}</Content>
     </View>
   );
 };

--- a/packages/spectrum/src/layouts/SpectrumHorizontalLayout.tsx
+++ b/packages/spectrum/src/layouts/SpectrumHorizontalLayout.tsx
@@ -71,7 +71,7 @@ const SpectrumHorizontalLayoutRenderer: FunctionComponent<RendererProps> = ({
       uischema={uischema}
       schema={schema}
     >
-      {renderChildren(horizontalLayout, schema, childrenStyles, path)}
+      {renderChildren(horizontalLayout, schema, childrenStyles, path, enabled)}
     </SpectrumLayout>
   );
 };

--- a/packages/spectrum/src/layouts/SpectrumVerticalLayout.tsx
+++ b/packages/spectrum/src/layouts/SpectrumVerticalLayout.tsx
@@ -71,7 +71,7 @@ export const SpectrumVerticalLayoutRenderer: FunctionComponent<RendererProps> = 
       enabled={enabled}
       path={path}
     >
-      {renderChildren(verticalLayout, schema, childrenStyles, path)}
+      {renderChildren(verticalLayout, schema, childrenStyles, path, enabled)}
     </SpectrumLayout>
   );
 };

--- a/packages/spectrum/src/layouts/util.tsx
+++ b/packages/spectrum/src/layouts/util.tsx
@@ -43,7 +43,8 @@ export const renderChildren = (
   layout: Layout,
   schema: JsonSchema,
   styleProps: StyleProps,
-  path: string
+  path: string,
+  enabled = true
 ) => {
   if (isEmpty(layout.elements)) {
     return [];
@@ -60,6 +61,7 @@ export const renderChildren = (
           uischema={child}
           schema={schema}
           path={path}
+          enabled={enabled}
         />
       </View>
     );

--- a/packages/spectrum/test/renderers/SpectrumHorizontalLayout.test.tsx
+++ b/packages/spectrum/test/renderers/SpectrumHorizontalLayout.test.tsx
@@ -31,21 +31,9 @@ import {
   SchemaBasedCondition,
   UISchemaElement,
 } from '@jsonforms/core';
-import Adapter from 'enzyme-adapter-react-16';
-import Enzyme, { ReactWrapper } from 'enzyme';
-import SpectrumHorizontalLayoutRenderer, {
-  spectrumHorizontalLayoutTester,
-} from '../../src/layouts/SpectrumHorizontalLayout';
-import { mountForm } from '../util';
-
-Enzyme.configure({ adapter: new Adapter() });
-
-const fixture = {
-  uischema: {
-    type: 'HorizontalLayout',
-    elements: [{ type: 'Control' }],
-  },
-};
+import '@testing-library/jest-dom';
+import { spectrumHorizontalLayoutTester } from '../../src/layouts/SpectrumHorizontalLayout';
+import { renderForm } from '../util';
 
 test('tester', () => {
   expect(spectrumHorizontalLayoutTester(undefined, undefined)).toBe(-1);
@@ -57,20 +45,44 @@ test('tester', () => {
 });
 
 describe('Horizontal layout', () => {
-  let wrapper: ReactWrapper;
+  const nameControl = {
+    type: 'Control',
+    label: 'Name',
+    scope: '#/properties/name',
+  };
 
-  afterEach(() => wrapper.unmount());
+  const colorControl = {
+    type: 'Control',
+    label: 'Color',
+    scope: '#/properties/color',
+  };
+
+  const fixture = {
+    data: {},
+    schema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        color: {
+          type: 'string',
+        },
+      },
+    },
+    uischema: {
+      type: 'HorizontalLayout',
+      elements: [nameControl, colorControl],
+    },
+  };
 
   test('render with undefined elements', () => {
     const uischema: UISchemaElement = {
       type: 'HorizontalLayout',
     };
-    wrapper = mountForm(uischema);
+    const { container } = renderForm(uischema, fixture.schema, fixture.data);
 
-    const horizontalLayout = wrapper
-      .find(SpectrumHorizontalLayoutRenderer)
-      .getDOMNode().firstElementChild;
-    expect(horizontalLayout?.children).toHaveLength(0);
+    expect(container.querySelectorAll('input')).toHaveLength(0);
   });
 
   test('render with null elements', () => {
@@ -78,58 +90,80 @@ describe('Horizontal layout', () => {
       type: 'HorizontalLayout',
       elements: null,
     };
-    wrapper = mountForm(uischema);
+    const { container } = renderForm(uischema, fixture.schema, fixture.data);
 
-    const horizontalLayout = wrapper
-      .find(SpectrumHorizontalLayoutRenderer)
-      .getDOMNode().firstElementChild;
-    expect(horizontalLayout?.children).toHaveLength(0);
+    expect(container.querySelectorAll('input')).toHaveLength(0);
   });
 
   test('render with children', () => {
-    const uischema: HorizontalLayout = {
-      type: 'HorizontalLayout',
-      elements: [{ type: 'Control' }, { type: 'Control' }],
-    };
-    wrapper = mountForm(uischema);
+    const { container } = renderForm(
+      fixture.uischema,
+      fixture.schema,
+      fixture.data
+    );
 
-    const horizontalLayout = wrapper
-      .find(SpectrumHorizontalLayoutRenderer)
-      .getDOMNode().firstElementChild;
-    expect(horizontalLayout?.children).toHaveLength(2);
+    expect(container.querySelectorAll('input')).toHaveLength(2);
   });
 
-  test('hide', () => {
+  test('visible by default', () => {
+    const { container } = renderForm(
+      fixture.uischema,
+      fixture.schema,
+      fixture.data
+    );
+
+    const element = container.firstElementChild
+      .firstElementChild as HTMLElement;
+    expect(element.style.display).not.toBe('none');
+  });
+
+  test('hidden', () => {
     // Condition that evaluates to false
     const condition: SchemaBasedCondition = {
       scope: '',
       schema: {},
     };
-    const uischema: UISchemaElement = {
-      ...fixture.uischema,
+    const uischema: HorizontalLayout = {
+      type: 'HorizontalLayout',
+      elements: [nameControl],
       rule: {
         effect: RuleEffect.HIDE,
         condition,
       },
     };
-    wrapper = mountForm(uischema);
+    const { container } = renderForm(uischema, fixture.schema, fixture.data);
 
-    const horizontalLayout = wrapper
-      .find(SpectrumHorizontalLayoutRenderer)
-      .getDOMNode() as HTMLElement;
-    expect(horizontalLayout.style.display).toBe('none');
+    const element = container.firstElementChild
+      .firstElementChild as HTMLElement;
+    expect(element.style.display).toBe('none');
   });
 
-  test('show by default', () => {
+  test('enabled by default', () => {
+    const { container } = renderForm(
+      fixture.uischema,
+      fixture.schema,
+      fixture.data
+    );
+
+    expect(container.querySelector('input').disabled).toBeFalsy();
+  });
+
+  test('disabled', () => {
+    // Condition that evaluates to false
+    const condition: SchemaBasedCondition = {
+      scope: '',
+      schema: {},
+    };
     const uischema: HorizontalLayout = {
       type: 'HorizontalLayout',
-      elements: [{ type: 'Control' }],
+      elements: [nameControl],
+      rule: {
+        effect: RuleEffect.DISABLE,
+        condition,
+      },
     };
-    wrapper = mountForm(uischema);
+    const { container } = renderForm(uischema, fixture.schema, fixture.data);
 
-    const horizontalLayout = wrapper
-      .find(SpectrumHorizontalLayoutRenderer)
-      .getDOMNode() as HTMLElement;
-    expect(horizontalLayout.style.display).not.toBe('none');
+    expect(container.querySelector('input').disabled).toBeTruthy();
   });
 });


### PR DESCRIPTION
Fixes #57

The `HorizontalLayout`, `VerticalLayout` and `GroupLayout` did not pass trough their enabled state to the children. Added some tests for this.