### PR TITLE
Make schemas editable, use 2 col layout, add CodeMirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6731,6 +6731,11 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codemirror": {
+      "version": "5.58.3",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.58.3.tgz",
+      "integrity": "sha512-KBhB+juiyOOgn0AqtRmWyAT3yoElkuvWTI6hsHa9E6GQrl6bk/fdAYcvuqW1/upO9T9rtEtapWdw4XYcNiVDEA=="
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -15696,6 +15701,11 @@
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
       }
+    },
+    "react-codemirror2": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
+      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
     },
     "react-dom": {
       "version": "16.14.0",

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -11,8 +11,10 @@
     "@react-spectrum/table": "^3.0.0-alpha.7",
     "@react-spectrum/tabs": "3.0.0-alpha.2",
     "@spectrum-icons/workflow": "^3.2.0",
+    "codemirror": "^5.58.3",
     "lodash": "^4.17.15",
     "react": "^16.12.0",
+    "react-codemirror2": "^7.2.1",
     "react-dom": "^16.12.0",
     "react-redux": "^7.2.1",
     "redux": "^4.0.4"

--- a/packages/example/src/App.css
+++ b/packages/example/src/App.css
@@ -1,37 +1,20 @@
+.App-Form, .App-Data {
+  width: 100%;
+}
+
 @media (min-width: 1200px) {
-  .container {
-    display: flex; /* or inline-flex */
-    flex-flow: row nowrap;
+  .App-Form, .App-Data {
+    display: inline-block;
+    vertical-align: top;
   }
 
-  .demoform {
-    width: 80%;
+  .App-Form {
+    width: 66.6%;
   }
-}
 
-.container > * {
-  flex: 1 100%;
-}
-
-.App-title {
-  font-size: 1em;
-}
-
-.App-intro {
-  font-size: medium;
-}
-
-.App-Form {
-  flex: 4 8 auto;
-  padding-top: 1em;
-}
-
-.App-selection {
-  flex: 1 auto;
-}
-
-.App-Data {
-  flex: 2 auto;
+  .App-Data {
+    width: 33.3%;
+  }
 }
 
 .data-title {
@@ -39,16 +22,6 @@
   margin-bottom: 0;
 }
 
-.demoform {
-  margin: auto;
-}
-
-.tabs {
-  position: relative;
-  min-height: 200px; /* This part sucks */
-  clear: both;
-  margin: 25px 0;
-}
 .content {
   position: absolute;
   top: 28px;
@@ -67,10 +40,8 @@
 [type='radio']:checked ~ label ~ .content {
   z-index: 1;
 }
-.Shell {
-  min-height: 100vh;
-  padding: 2em;
-  padding-top: 1em;
-  padding-bottom: 3em;
-  box-sizing: border-box;
+
+.CodeMirror {
+  font-size: 0.8em;
+  min-height: 50em;
 }

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -26,89 +26,99 @@
   THE SOFTWARE.
 */
 
-import React, { Component } from 'react';
+import React, { useCallback } from 'react';
 import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';
 import {
+  Heading,
   Picker,
   Item,
   Section,
   Content,
-  TextArea,
+  View,
 } from '@adobe/react-spectrum';
 import { Tabs } from '@react-spectrum/tabs';
 import './App.css';
 import { AppProps, initializedConnect } from './reduxUtil';
+import { TextArea } from './TextArea';
 
-class App extends Component<AppProps> {
-  render() {
-    return (
-      <JsonFormsReduxContext>
-        <div className='Shell'>
-          <div className='container'>
-            <div className='App-selection'>
-              <h4 className='data-title'>JsonForms Examples</h4>
-              <ExamplesPicker {...this.props} />
-            </div>
+function App(props: AppProps) {
+  const setExampleByName = useCallback((exampleName: string) => {
+    props.changeExample(props.examples.find((example) => example.name === exampleName));
+  }, [props.changeExample, props.examples]);
 
-            <div className='App-Form'>
-              <div className='demoform'>
-                {this.props.getExtensionComponent()}
-                <JsonFormsDispatch onChange={this.props.onChange} />
-              </div>
-            </div>
+  const updateCurrentSchema = useCallback((newSchema: string) => {
+    props.changeExample({ ...props.selectedExample, schema: JSON.parse(newSchema) });
+  }, [props.changeExample, props.selectedExample]);
 
-            <div className='App-Data tabs'>
-              <Tabs defaultSelectedKey='boundData'>
+  const updateCurrentUISchema = useCallback((newUISchema: string) => {
+    props.changeExample({ ...props.selectedExample, uischema: JSON.parse(newUISchema) });
+  }, [props.changeExample, props.selectedExample]);
+
+  const updateCurrentData = useCallback((newData: string) => {
+    props.changeExample({ ...props.selectedExample, data: JSON.parse(newData) });
+  }, [props.changeExample, props.selectedExample]);
+
+  return (
+    <JsonFormsReduxContext>
+      <View padding='size-100' minHeight='100vh' paddingTop='0' paddingBottom='size-800'>
+        <div className='container'>
+          <div className='App-Form'>
+            <View padding="size-100">
+              <Heading>{props.selectedExample.label}</Heading>
+              {props.getExtensionComponent()}
+              <JsonFormsDispatch onChange={props.onChange} />
+            </View>
+          </div>
+
+          <div className='App-Data tabs'>
+            <View padding='size-100'>
+              <Heading>JsonForms Examples</Heading>
+              <ExamplesPicker {...props} onChange={setExampleByName} />
+              <Tabs defaultSelectedKey='schema'>
                 <Item key='boundData' title='Bound data'>
                   <Content margin='size-100'>
                     <TextArea
-                      width='100%'
-                      height='30em'
-                      aria-label='Bound data'
-                      value={this.props.dataAsString}
+                      value={props.dataAsString}
+                      onChange={updateCurrentData}
                     />
                   </Content>
                 </Item>
                 <Item key='uiSchema' title='UI Schema'>
                   <Content margin='size-100'>
                     <TextArea
-                      width='100%'
-                      height='30em'
-                      aria-label='UI Schema'
                       value={JSON.stringify(
-                        this.props.selectedExample.uischema,
+                        props.selectedExample.uischema,
                         null,
                         2
-                      )}
+                      ) || ''}
+                      onChange={updateCurrentUISchema}
                     />
                   </Content>
                 </Item>
                 <Item key='schema' title='Schema'>
                   <Content margin='size-100'>
                     <TextArea
-                      width='100%'
-                      height='30em'
-                      aria-label='UI Schema'
                       value={JSON.stringify(
-                        this.props.selectedExample.schema,
+                        props.selectedExample.schema,
                         null,
                         2
-                      )}
+                      ) || ''}
+                      onChange={updateCurrentSchema}
                     />
                   </Content>
                 </Item>
               </Tabs>
-            </div>
+            </View>
           </div>
         </div>
-      </JsonFormsReduxContext>
-    );
-  }
+      </View>
+    </JsonFormsReduxContext>
+  );
 }
 
 export default initializedConnect(App);
 
-function ExamplesPicker(props: AppProps) {
+function ExamplesPicker(props: Omit<AppProps, "onChange"> & { onChange: (exampleName: string) => void }) {
   const options = [
     {
       name: 'React Spectrum Tests',
@@ -130,11 +140,11 @@ function ExamplesPicker(props: AppProps) {
       items={options}
       width='100%'
       defaultSelectedKey={props.selectedExample.name}
-      onSelectionChange={props.changeExample}
+      onSelectionChange={props.onChange}
     >
       {(item) => (
         <Section key={item.name} items={item.children} title={item.name}>
-          {(item) => <Item>{item.name}</Item>}
+          {(item) => <Item>{item.label}</Item>}
         </Section>
       )}
     </Picker>

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -42,28 +42,56 @@ import { AppProps, initializedConnect } from './reduxUtil';
 import { TextArea } from './TextArea';
 
 function App(props: AppProps) {
-  const setExampleByName = useCallback((exampleName: string) => {
-    props.changeExample(props.examples.find((example) => example.name === exampleName));
-  }, [props.changeExample, props.examples]);
+  const setExampleByName = useCallback(
+    (exampleName: string) => {
+      props.changeExample(
+        props.examples.find((example) => example.name === exampleName)
+      );
+    },
+    [props.changeExample, props.examples]
+  );
 
-  const updateCurrentSchema = useCallback((newSchema: string) => {
-    props.changeExample({ ...props.selectedExample, schema: JSON.parse(newSchema) });
-  }, [props.changeExample, props.selectedExample]);
+  const updateCurrentSchema = useCallback(
+    (newSchema: string) => {
+      props.changeExample({
+        ...props.selectedExample,
+        schema: JSON.parse(newSchema),
+      });
+    },
+    [props.changeExample, props.selectedExample]
+  );
 
-  const updateCurrentUISchema = useCallback((newUISchema: string) => {
-    props.changeExample({ ...props.selectedExample, uischema: JSON.parse(newUISchema) });
-  }, [props.changeExample, props.selectedExample]);
+  const updateCurrentUISchema = useCallback(
+    (newUISchema: string) => {
+      props.changeExample({
+        ...props.selectedExample,
+        uischema: JSON.parse(newUISchema),
+      });
+    },
+    [props.changeExample, props.selectedExample]
+  );
 
-  const updateCurrentData = useCallback((newData: string) => {
-    props.changeExample({ ...props.selectedExample, data: JSON.parse(newData) });
-  }, [props.changeExample, props.selectedExample]);
+  const updateCurrentData = useCallback(
+    (newData: string) => {
+      props.changeExample({
+        ...props.selectedExample,
+        data: JSON.parse(newData),
+      });
+    },
+    [props.changeExample, props.selectedExample]
+  );
 
   return (
     <JsonFormsReduxContext>
-      <View padding='size-100' minHeight='100vh' paddingTop='0' paddingBottom='size-800'>
+      <View
+        padding='size-100'
+        minHeight='100vh'
+        paddingTop='0'
+        paddingBottom='size-800'
+      >
         <div className='container'>
           <div className='App-Form'>
-            <View padding="size-100">
+            <View padding='size-100'>
               <Heading>{props.selectedExample.label}</Heading>
               {props.getExtensionComponent()}
               <JsonFormsDispatch onChange={props.onChange} />
@@ -86,11 +114,13 @@ function App(props: AppProps) {
                 <Item key='uiSchema' title='UI Schema'>
                   <Content margin='size-100'>
                     <TextArea
-                      value={JSON.stringify(
-                        props.selectedExample.uischema,
-                        null,
-                        2
-                      ) || ''}
+                      value={
+                        JSON.stringify(
+                          props.selectedExample.uischema,
+                          null,
+                          2
+                        ) || ''
+                      }
                       onChange={updateCurrentUISchema}
                     />
                   </Content>
@@ -98,11 +128,10 @@ function App(props: AppProps) {
                 <Item key='schema' title='Schema'>
                   <Content margin='size-100'>
                     <TextArea
-                      value={JSON.stringify(
-                        props.selectedExample.schema,
-                        null,
-                        2
-                      ) || ''}
+                      value={
+                        JSON.stringify(props.selectedExample.schema, null, 2) ||
+                        ''
+                      }
                       onChange={updateCurrentSchema}
                     />
                   </Content>
@@ -118,7 +147,11 @@ function App(props: AppProps) {
 
 export default initializedConnect(App);
 
-function ExamplesPicker(props: Omit<AppProps, "onChange"> & { onChange: (exampleName: string) => void }) {
+function ExamplesPicker(
+  props: Omit<AppProps, 'onChange'> & {
+    onChange: (exampleName: string) => void;
+  }
+) {
   const options = [
     {
       name: 'React Spectrum Tests',

--- a/packages/example/src/ColorSchemeContext.ts
+++ b/packages/example/src/ColorSchemeContext.ts
@@ -1,0 +1,29 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import { createContext } from 'react';
+export const ColorSchemeContext = createContext<'light' | 'dark'>('dark');

--- a/packages/example/src/ColorSchemeContext.ts
+++ b/packages/example/src/ColorSchemeContext.ts
@@ -1,9 +1,6 @@
 /*
   The MIT License
 
-  Copyright (c) 2017-2019 EclipseSource Munich
-  https://github.com/eclipsesource/jsonforms
-
   Copyright (c) 2020 headwire.com, Inc
   https://github.com/headwirecom/jsonforms-react-spectrum-renderers
 

--- a/packages/example/src/TextArea.tsx
+++ b/packages/example/src/TextArea.tsx
@@ -1,9 +1,6 @@
 /*
   The MIT License
 
-  Copyright (c) 2017-2019 EclipseSource Munich
-  https://github.com/eclipsesource/jsonforms
-
   Copyright (c) 2020 headwire.com, Inc
   https://github.com/headwirecom/jsonforms-react-spectrum-renderers
 

--- a/packages/example/src/TextArea.tsx
+++ b/packages/example/src/TextArea.tsx
@@ -1,0 +1,97 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/theme/mbo.css';
+import 'codemirror/theme/base16-light.css';
+import React, { useCallback, useContext, useState } from 'react';
+import { UnControlled as CodeMirror } from 'react-codemirror2';
+import { ColorSchemeContext } from './ColorSchemeContext';
+import { ButtonGroup, Button, StatusLight, View } from '@adobe/react-spectrum';
+
+import 'codemirror/mode/javascript/javascript';
+
+export function TextArea(props: {
+  value: string;
+  onChange: (newValue: string) => void;
+}) {
+  const colorScheme = useContext(ColorSchemeContext);
+  const [value, setValue] = useState(props.value);
+  const err = getErr(value);
+  const [key, setKey] = useState(Math.random()); // used to force-rerender CodeMirror when Reset button is clicked
+  const reset = useCallback(() => {
+    setValue(props.value);
+    setKey(Math.random());
+  }, [props.value]);
+  const save = useCallback(() => {
+    props.onChange(value);
+  }, [value]);
+
+  return (
+    <>
+      <CodeMirror
+        key={key}
+        value={props.value}
+        options={{
+          mode: 'application/json',
+          theme: colorScheme === 'dark' ? 'mbo' : 'default',
+          lineNumbers: true,
+        }}
+        onChange={(_, __, value) => setValue(value)}
+      />
+      <View paddingTop='size-50'>
+        {value && err && <StatusLight variant='negative'>{err}</StatusLight>}
+        {value && !err && (
+          <StatusLight variant='positive'>Valid JSON</StatusLight>
+        )}
+        {value !== props.value && (
+          <ButtonGroup>
+            <Button variant='cta' onPress={save} isDisabled={!!err}>
+              Save
+            </Button>
+            <Button variant='primary' onPress={reset}>
+              Reset
+            </Button>
+          </ButtonGroup>
+        )}
+      </View>
+    </>
+  );
+}
+
+function getErr(value: string) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    JSON.parse(value);
+    return null;
+  } catch (err) {
+    return String(err);
+  }
+}

--- a/packages/example/src/index.css
+++ b/packages/example/src/index.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   padding: 0;

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -26,11 +26,7 @@
   THE SOFTWARE.
 */
 import { Actions, getData, JsonFormsCore } from '@jsonforms/core';
-import {
-  CHANGE_EXAMPLE,
-  changeExample,
-  ExampleDescription,
-} from '@jsonforms/examples';
+import { CHANGE_EXAMPLE, changeExample } from '@jsonforms/examples';
 import { ReactExampleDescription } from './util';
 import * as React from 'react';
 import { connect } from 'react-redux';
@@ -59,7 +55,7 @@ export interface ExampleStateProps {
 }
 
 export interface ExampleDispatchProps {
-  changeExampleData(example: ReactExampleDescription): void;
+  changeExample(example: ReactExampleDescription): void;
   getComponent(example: ReactExampleDescription): React.Component;
   onChange?(
     example: ReactExampleDescription
@@ -67,7 +63,7 @@ export interface ExampleDispatchProps {
 }
 
 export interface AppProps extends ExampleStateProps {
-  changeExample(exampleName: string): void;
+  changeExample(example: ReactExampleDescription): void;
   getExtensionComponent(): React.Component;
   onChange?(state: Pick<JsonFormsCore, 'data' | 'errors'>): AnyAction;
 }
@@ -85,7 +81,7 @@ const mapStateToProps = (state: any) => {
   };
 };
 const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
-  changeExampleData: (example: ReactExampleDescription) => {
+  changeExample: (example: ReactExampleDescription) => {
     dispatch(changeExample(example));
     dispatch(Actions.init(example.data, example.schema, example.uischema));
     dispatch(Actions.setConfig(example.config));
@@ -104,12 +100,7 @@ const mergeProps = (
 ): AppProps => {
   return Object.assign({}, ownProps, {
     ...stateProps,
-    changeExample: (exampleName: string) =>
-      dispatchProps.changeExampleData(
-        stateProps.examples.find(
-          (e: ExampleDescription) => e.name === exampleName
-        )
-      ),
+    changeExample: dispatchProps.changeExample,
     getExtensionComponent: () =>
       dispatchProps.getComponent(stateProps.selectedExample),
     onChange:


### PR DESCRIPTION
- [x] Make Schema, UISchema, Data textboxes editable
- [x] Add CodeMirror editor to those textboxes
- [x] Move Example selectbox above the textboxes to save space (now it's a 2 column layout)

![editable2](https://user-images.githubusercontent.com/2631515/102028292-1b836100-3db2-11eb-8bf9-4583ab4654f5.gif)
