### PR TITLE
Make the style of date picker more aligned with other fields

### DIFF
--- a/packages/spectrum/src/additional/DatePicker.css
+++ b/packages/spectrum/src/additional/DatePicker.css
@@ -1,0 +1,9 @@
+/**
+ * Makes the little calendar icon grey on Chrome
+ * Otherwise it's not visible with dark mode styles
+ */
+::-webkit-calendar-picker-indicator {
+  filter: invert(0.5);
+  position: relative;
+  top: 2px;
+}

--- a/packages/spectrum/src/additional/DatePicker.tsx
+++ b/packages/spectrum/src/additional/DatePicker.tsx
@@ -1,9 +1,6 @@
 /*
   The MIT License
 
-  Copyright (c) 2017-2019 EclipseSource Munich
-  https://github.com/eclipsesource/jsonforms
-
   Copyright (c) 2020 headwire.com, Inc
   https://github.com/headwirecom/jsonforms-react-spectrum-renderers
 

--- a/packages/spectrum/src/additional/DatePicker.tsx
+++ b/packages/spectrum/src/additional/DatePicker.tsx
@@ -1,0 +1,89 @@
+/*
+  The MIT License
+
+  Copyright (c) 2017-2019 EclipseSource Munich
+  https://github.com/eclipsesource/jsonforms
+
+  Copyright (c) 2020 headwire.com, Inc
+  https://github.com/headwirecom/jsonforms-react-spectrum-renderers
+
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+import React from 'react';
+import './DatePicker.css';
+
+/**
+ * React Spectrum does not have date picker (it is in progress, not usable at the time of writing).
+ * We can make the default date picker look more consistent with other React Spectrum elements by
+ * copying the same styles as React Spectrum applies to TextField and FieldLabel.
+ */
+const inputStyle: React.CSSProperties = {
+  border: `var(--spectrum-alias-border-size-thin,var(--spectrum-global-dimension-static-size-10)) solid`,
+  borderRadius: `var(--spectrum-alias-border-radius-regular,var(--spectrum-global-dimension-size-50))`,
+  boxSizing: 'border-box',
+  padding: `3px var(--spectrum-global-dimension-size-150) 5px calc(var(--spectrum-global-dimension-size-150) - 1px)`,
+  textIndent: `0`,
+  width: `100%`,
+  height: `var(--spectrum-alias-single-line-height,var(--spectrum-global-dimension-size-400))`,
+  verticalAlign: `top`,
+  margin: `0`,
+  overflow: `visible`,
+  fontFamily: `adobe-clean-ux,adobe-clean,Source Sans Pro,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif`,
+  fontSize: `var(--spectrum-alias-font-size-default,var(--spectrum-global-dimension-font-size-100))`,
+  lineHeight: `var(--spectrum-alias-body-text-line-height,var(--spectrum-global-font-line-height-medium))`,
+  textOverflow: `ellipsis`,
+  transition: `border-color .13s ease-in-out,box-shadow .13s ease-in-out`,
+  outline: `none`,
+  backgroundColor: `var(--spectrum-global-color-gray-50)`,
+  borderColor: `var(--spectrum-alias-border-color,var(--spectrum-global-color-gray-400))`,
+  color: `var(--spectrum-alias-text-color,var(--spectrum-global-color-gray-800))`,
+};
+
+const labelStyle: React.CSSProperties = {
+  boxSizing: 'border-box',
+  padding: `var(--spectrum-global-dimension-size-50) 0 var(--spectrum-global-dimension-size-65)`,
+  fontSize: `var(--spectrum-global-dimension-font-size-75)`,
+  fontWeight: `var(--spectrum-global-font-weight-regular,400)` as React.CSSProperties['fontWeight'],
+  lineHeight: `var(--spectrum-global-font-line-height-small,1.3)`,
+  verticalAlign: `top`,
+  WebkitFontSmoothing: `subpixel-antialiased`,
+  MozOsxFontSmoothing: `auto`,
+  cursor: `default`,
+};
+
+export const DatePicker: React.FC<React.ComponentProps<'input'>> = (props) => {
+  return (
+    <input
+      {...props}
+      style={props.style ? { ...inputStyle, ...props.style } : inputStyle}
+    />
+  );
+};
+
+export const DatePickerLabel: React.FC<React.ComponentProps<'label'>> = (
+  props
+) => {
+  return (
+    <label
+      {...props}
+      style={props.style ? { ...labelStyle, ...props.style } : labelStyle}
+    />
+  );
+};

--- a/packages/spectrum/src/cells/DateCell.tsx
+++ b/packages/spectrum/src/cells/DateCell.tsx
@@ -33,12 +33,13 @@ import {
   rankWith,
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
+import { DatePicker } from '../additional/DatePicker';
 
 export const DateCell = (props: CellProps) => {
   const { data, id, enabled, uischema, path, handleChange } = props;
 
   return (
-    <input
+    <DatePicker
       type='date'
       value={data ?? ''}
       onChange={(ev) => handleChange(path, ev.target.value)}

--- a/packages/spectrum/src/cells/DateTimeCell.tsx
+++ b/packages/spectrum/src/cells/DateTimeCell.tsx
@@ -33,6 +33,7 @@ import {
   rankWith,
 } from '@jsonforms/core';
 import { withJsonFormsCellProps } from '@jsonforms/react';
+import { DatePicker } from '../additional/DatePicker';
 
 export const DateTimeCell = (props: CellProps) => {
   const { data, id, enabled, uischema, path, handleChange } = props;
@@ -41,7 +42,7 @@ export const DateTimeCell = (props: CellProps) => {
   };
 
   return (
-    <input
+    <DatePicker
       type='datetime-local'
       value={(data ?? '').substr(0, 16)}
       onChange={(ev) => handleChange(path, toISOString(ev.target.value))}

--- a/packages/spectrum/src/spectrum-control/InputDate.tsx
+++ b/packages/spectrum/src/spectrum-control/InputDate.tsx
@@ -28,6 +28,7 @@ import { merge } from 'lodash';
 import { SpectrumInputProps } from './index';
 import { DimensionValue } from '@react-types/shared';
 import { Flex } from '@adobe/react-spectrum';
+import { DatePicker, DatePickerLabel } from '../additional/DatePicker';
 
 export class InputDate extends React.PureComponent<
   CellProps & SpectrumInputProps
@@ -53,15 +54,14 @@ export class InputDate extends React.PureComponent<
 
     return (
       <Flex direction='column'>
-        <label htmlFor={id + '-input'}>
+        <DatePickerLabel htmlFor={id + '-input'}>
           {computeLabel(
             label,
             required,
             appliedUiSchemaOptions.hideRequiredAsterisk
           )}
-        </label>
-        <input
-          style={{ marginTop: '3px', padding: '5px' }}
+        </DatePickerLabel>
+        <DatePicker
           width={width}
           type='date'
           value={data ?? ''}

--- a/packages/spectrum/src/spectrum-control/InputDateTime.tsx
+++ b/packages/spectrum/src/spectrum-control/InputDateTime.tsx
@@ -28,6 +28,7 @@ import { CellProps, computeLabel } from '@jsonforms/core';
 import { merge } from 'lodash';
 import { SpectrumInputProps } from './index';
 import { Flex } from '@adobe/react-spectrum';
+import { DatePicker, DatePickerLabel } from '../additional/DatePicker';
 
 export class InputDateTime extends React.PureComponent<
   CellProps & SpectrumInputProps
@@ -57,15 +58,14 @@ export class InputDateTime extends React.PureComponent<
 
     return (
       <Flex direction='column'>
-        <label htmlFor={id + '-input'}>
+        <DatePickerLabel htmlFor={id + '-input'}>
           {computeLabel(
             label,
             required,
             appliedUiSchemaOptions.hideRequiredAsterisk
           )}
-        </label>
-        <input
-          style={{ marginTop: '3px', padding: '5px' }}
+        </DatePickerLabel>
+        <DatePicker
           type='datetime-local'
           width={width}
           value={(data ?? '').substr(0, 16)}

--- a/packages/spectrum/src/spectrum-control/InputTime.tsx
+++ b/packages/spectrum/src/spectrum-control/InputTime.tsx
@@ -28,6 +28,7 @@ import { merge } from 'lodash';
 import { SpectrumInputProps } from './index';
 import { DimensionValue } from '@react-types/shared';
 import { Flex } from '@adobe/react-spectrum';
+import { DatePicker, DatePickerLabel } from '../additional/DatePicker';
 
 export class InputTime extends React.PureComponent<
   CellProps & SpectrumInputProps
@@ -53,16 +54,15 @@ export class InputTime extends React.PureComponent<
 
     return (
       <Flex direction='column'>
-        <label htmlFor={id + '-input'}>
+        <DatePickerLabel htmlFor={id + '-input'}>
           {computeLabel(
             label,
             required,
             appliedUiSchemaOptions.hideRequiredAsterisk
           )}
-        </label>
-        <input
+        </DatePickerLabel>
+        <DatePicker
           width={width}
-          style={{ marginTop: '3px', padding: '5px' }}
           type='time'
           value={data ?? ''}
           onChange={(ev) => handleChange(path, ev.target.value)}


### PR DESCRIPTION
- [x] Use date input styles copied from React-Spectrum's TextField
- [x] Use date input label's styles copied from React-Spectrum's FieldLabel
- [x] Make sure the little calendar icon is visible on both light and dark theme on Chrome

![Screenshot 2020-12-14 at 04 06 38-min](https://user-images.githubusercontent.com/2631515/102032665-1cbc8a00-3dc2-11eb-9f8b-65fef05d05c2.png)
![Screenshot 2020-12-14 at 04 04 54-min](https://user-images.githubusercontent.com/2631515/102032674-1fb77a80-3dc2-11eb-99e4-a32d97a1f8c8.png)
