### PR TITLE
add source sans pro font to the example

### DIFF
--- a/packages/spectrum/example/index.html
+++ b/packages/spectrum/example/index.html
@@ -7,6 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="assets/example.css" />
 
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro&display=swap"
+      rel="stylesheet"
+    />
+
     <script src="samples.js"></script>
   </head>
 


### PR DESCRIPTION
I think for the example page it's enough if we just use the google fonts API. Thoughts?