### PR TITLE
Turn on strict mode, validate packages on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - npm run init
 
 script:
+  - npm run validate
   - npm run build
   - npm run bundle
   - npm run test-cov

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "clean": "lerna run clean",
     "test": "lerna run test",
     "test-cov": "lerna run test-cov",
+    "validate": "lerna run validate",
     "lint": "tslint 'packages/**/*.{ts,tsx}' -c ./tslint.json"
   },
   "devDependencies": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -20,6 +20,7 @@
     "redux": "^4.0.4"
   },
   "scripts": {
+    "validate": "../../node_modules/.bin/tsc --noEmit",
     "build": "echo 'Nothing to do'",
     "test": "echo 'Nothing to do'"
   }

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -43,10 +43,13 @@ import { TextArea } from './TextArea';
 
 function App(props: AppProps) {
   const setExampleByName = useCallback(
-    (exampleName: string) => {
-      props.changeExample(
-        props.examples.find((example) => example.name === exampleName)
+    (exampleName: string | number) => {
+      const example = props.examples.find(
+        (example) => example.name === exampleName
       );
+      if (example) {
+        props.changeExample(example);
+      }
     },
     [props.changeExample, props.examples]
   );
@@ -149,7 +152,7 @@ export default initializedConnect(App);
 
 function ExamplesPicker(
   props: Omit<AppProps, 'onChange'> & {
-    onChange: (exampleName: string) => void;
+    onChange: (exampleName: string | number) => void;
   }
 ) {
   const options = [

--- a/packages/example/src/geographical-location.schema.ts
+++ b/packages/example/src/geographical-location.schema.ts
@@ -44,4 +44,4 @@ export default {
       maximum: 180,
     },
   },
-} as any;
+};

--- a/packages/example/src/index.tsx
+++ b/packages/example/src/index.tsx
@@ -59,16 +59,6 @@ import {
 const getExampleSchemas = () => {
   if (window.samples) {
     registerExamples(window.samples);
-  } else {
-    registerExamples([
-      {
-        name: 'spectrum-test',
-        label: 'test',
-        data: { name: 'a sample name' },
-        schema: undefined,
-        uischema: undefined,
-      },
-    ]);
   }
 
   const examples = getExamples();
@@ -90,9 +80,10 @@ const setupStore = (
       renderers: renderers,
     },
     examples: {
+      selectedExample: exampleData[exampleData.length - 1],
       data: exampleData,
     },
-  } as any);
+  });
 
   // Resolve example configuration
   // Add schema to validation

--- a/packages/example/src/reduxUtil.ts
+++ b/packages/example/src/reduxUtil.ts
@@ -56,10 +56,10 @@ export interface ExampleStateProps {
 
 export interface ExampleDispatchProps {
   changeExample(example: ReactExampleDescription): void;
-  getComponent(example: ReactExampleDescription): React.Component;
+  getComponent(example: ReactExampleDescription): React.Component | null;
   onChange?(
     example: ReactExampleDescription
-  ): (state: Pick<JsonFormsCore, 'data' | 'errors'>) => void;
+  ): ((state: Pick<JsonFormsCore, 'data' | 'errors'>) => void) | null;
 }
 
 export interface AppProps extends ExampleStateProps {
@@ -70,17 +70,17 @@ export interface AppProps extends ExampleStateProps {
 
 const mapStateToProps = (state: any) => {
   const examples = state.examples.data;
-  const selectedExample =
-    state.examples.selectedExample || examples[examples.length - 1];
   const extensionState = state.examples.extensionState;
   return {
     dataAsString: JSON.stringify(getData(state), null, 2),
     examples,
-    selectedExample,
+    selectedExample: state.examples.selectedExample,
     extensionState,
   };
 };
-const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
+const mapDispatchToProps = (
+  dispatch: Dispatch<AnyAction>
+): ExampleDispatchProps => ({
   changeExample: (example: ReactExampleDescription) => {
     dispatch(changeExample(example));
     dispatch(Actions.init(example.data, example.schema, example.uischema));
@@ -91,7 +91,7 @@ const mapDispatchToProps = (dispatch: Dispatch<AnyAction>) => ({
       ? example.customReactExtension(dispatch)
       : null,
   onChange: (example: ReactExampleDescription) =>
-    example.onChange ? example.onChange(dispatch) : undefined,
+    example.onChange ? example.onChange(dispatch) : null,
 });
 const mergeProps = (
   stateProps: ExampleStateProps,
@@ -105,8 +105,7 @@ const mergeProps = (
       dispatchProps.getComponent(stateProps.selectedExample),
     onChange:
       dispatchProps.onChange &&
-      dispatchProps.onChange(stateProps.selectedExample) &&
-      dispatchProps.onChange(stateProps.selectedExample)(
+      dispatchProps.onChange(stateProps.selectedExample)?.(
         stateProps.extensionState
       ),
   });
@@ -119,7 +118,13 @@ interface ExamplesState {
 
 const initState: ExamplesState = {
   data: [],
-  selectedExample: undefined,
+  selectedExample: {
+    name: 'init',
+    label: 'Init',
+    data: undefined,
+    schema: {},
+    uischema: { type: 'HorizontalLayout' },
+  },
 };
 
 export const exampleReducer = (

--- a/packages/example/tsconfig.json
+++ b/packages/example/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/spectrum/package.json
+++ b/packages/spectrum/package.json
@@ -19,6 +19,7 @@
     "report": "../../node_modules/.bin/nyc report --reporter=html",
     "test": "jest --no-cache",
     "test-cov": "jest --no-cache --coverage",
+    "validate": "../../node_modules/.bin/tsc --noEmit",
     "doc": "../../node_modules/.bin/typedoc --name 'JSON Forms React Spectrum Renderers' --mode file --excludeExternals --theme ../../typedoc-jsonforms --out docs src"
   },
   "keywords": [


### PR DESCRIPTION
- [x] Turn on TypeScript's strict mode in `packages/example` so it properly validates types and avoids runtime errors
- [x] Adjust types to fix TypeScript errors
- [x] Add a validation step in CI which checks for TypeScript errors before building 