### PR TITLE
Switch to hash router so that github pages + base tag works

### DIFF
--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -170,7 +170,7 @@ function AppWithExampleInURL(props: AppProps) {
 
   const selectedExample = urlParams.name
     ? examples.find(({ name }) => urlParams.name === name)
-    : examples[examples.length - 1];
+    : props.examples[props.examples.length - 1];
 
   const changeExample = useCallback(
     (example: ReactExampleDescription) => {
@@ -191,15 +191,16 @@ function AppWithExampleInURL(props: AppProps) {
   useEffect(() => {
     if (selectedExample) {
       props.changeExample(selectedExample);
+    } else {
+      history.push('/');
     }
-  }, [selectedExample]);
+  }, [selectedExample, history]);
 
   // If name is invalid, redirect to home
   if (!selectedExample) {
     console.error(
       `Could not find an example with name "${urlParams.name}", redirecting to /`
     );
-    history.push('/');
     return null;
   }
 

--- a/packages/example/src/index.tsx
+++ b/packages/example/src/index.tsx
@@ -27,7 +27,7 @@
 */
 import ReactDOM from 'react-dom';
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Switch,
   Redirect,
   Route,


### PR DESCRIPTION
- [x] Switch to HashRouter
- [x] Make default selected example be consistent
- [x] Put redirect into useEffect when rendering an invalid route (avoids a console error)