### PR TITLE
Bug/58 recursive add exception

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -24,6 +24,30 @@
   "scripts": {
     "validate": "../../node_modules/.bin/tsc --noEmit",
     "build": "echo 'Nothing to do'",
-    "test": "echo 'Nothing to do'"
+    "test": "jest --no-cache"
+  },
+  "devDependencies": {
+    "jest": "^26.6.3",
+    "ts-jest": "^24.2.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js"
+    ],
+    "transform": {
+      "^.+\\.(ts|tsx)$": "ts-jest"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@react-spectrum)/)"
+    ],
+    "testMatch": [
+      "**/test/**/*.test.tsx"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   }
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -27,7 +27,7 @@
     "test": "jest --no-cache"
   },
   "devDependencies": {
-    "jest": "^26.6.3",
+    "jest": "^24.9.0",
     "ts-jest": "^24.2.0"
   },
   "jest": {

--- a/packages/example/src/App.tsx
+++ b/packages/example/src/App.tsx
@@ -38,7 +38,7 @@ import {
   ExampleDispatchProps,
 } from './reduxUtil';
 import { TextArea } from './TextArea';
-import { ReactExampleDescription } from './util';
+import { circularReferenceReplacer, ReactExampleDescription } from './util';
 import {
   getExamplesFromLocalStorage,
   setExampleInLocalStorage,
@@ -131,7 +131,7 @@ function App(props: AppProps & { selectedExample: ReactExampleDescription }) {
                       value={
                         JSON.stringify(
                           props.selectedExample.uischema,
-                          null,
+                          circularReferenceReplacer(),
                           2
                         ) || ''
                       }
@@ -143,8 +143,11 @@ function App(props: AppProps & { selectedExample: ReactExampleDescription }) {
                   <Content margin='size-100'>
                     <TextArea
                       value={
-                        JSON.stringify(props.selectedExample.schema, null, 2) ||
-                        ''
+                        JSON.stringify(
+                          props.selectedExample.schema,
+                          circularReferenceReplacer(),
+                          2
+                        ) || ''
                       }
                       onChange={updateCurrentSchema}
                     />

--- a/packages/example/src/util.tsx
+++ b/packages/example/src/util.tsx
@@ -305,3 +305,29 @@ export const enhanceExample: (
         return e;
     }
   });
+
+/**
+ * Replacer to allow circular references in JSON.stringify
+ */
+export function circularReferenceReplacer() {
+  let m = new Map(),
+    v = new Map(),
+    init: any = null;
+
+  return function (this: Object, field: string, value: any) {
+    let p = m.get(this) + '/' + field;
+    let isComplex = value === Object(value);
+
+    if (isComplex) m.set(value, p);
+
+    let pp = v.get(value) || '';
+    let path = p.replace(/undefined\/\/?/, '');
+    let val = pp ? { $ref: `#/${pp}` } : value;
+
+    !init ? (init = value) : val === init ? (val = '#/') : 0;
+
+    if (!pp && isComplex) v.set(value, path);
+
+    return val;
+  };
+}

--- a/packages/example/test/util.test.tsx
+++ b/packages/example/test/util.test.tsx
@@ -1,0 +1,102 @@
+import { circularReferenceReplacer } from '../src/util';
+
+const stringify = (obj: any) =>
+  JSON.stringify(obj, circularReferenceReplacer());
+
+describe('circularReferenceReplacer', () => {
+  test('with emtpy values', () => {
+    // given
+    const undefObj: any = {
+      val: undefined,
+    };
+
+    // when
+    const undefResult = stringify(undefObj);
+
+    // expect
+    expect(undefResult).toEqual(`{}`);
+
+    // given
+    const nullObj: any = {
+      val: null,
+    };
+
+    // when
+    const nullResult = stringify(nullObj);
+
+    // expect
+    expect(nullResult).toEqual(`{"val":null}`);
+
+    // given
+    const emptyStringObj: any = {
+      val: '',
+    };
+
+    // when
+    const emptyStringRes = stringify(emptyStringObj);
+
+    // expect
+    expect(emptyStringRes).toEqual(`{"val":""}`);
+  });
+
+  test('with non-circular objects', () => {
+    // given
+    const obj: any = {
+      a: 'foo',
+      b: 'bar',
+      nested: {
+        c: 'baz',
+      },
+    };
+
+    // when
+    const result = stringify(obj);
+
+    // then
+    expect(result).toEqual(`{"a":"foo","b":"bar","nested":{"c":"baz"}}`);
+  });
+
+  test('with circular object', () => {
+    // given
+    const obj: any = {
+      a: {
+        prop: 'foo',
+        nested: {
+          prop: 'bar',
+        },
+      },
+    };
+
+    obj.a['prop2'] = obj.a;
+
+    obj['b'] = {
+      foo: obj.a,
+      bar: obj.a.nested,
+    };
+
+    // when
+    const result = stringify(obj);
+
+    // then
+    expect(result).toEqual(
+      `{"a":{"prop":"foo","nested":{"prop":"bar"},"prop2":{"$ref":"#/a"}},"b":{"foo":{"$ref":"#/a"},"bar":{"$ref":"#/a/nested"}}}`
+    );
+  });
+
+  test('with root reference', () => {
+    // given
+    const obj: any = {
+      a: {
+        prop: 'foo',
+      },
+    };
+
+    obj['b'] = obj;
+
+    // when
+    const result = stringify(obj);
+
+    // then
+    expect(result).toEqual(`{"a":{"prop":"foo"},"b":"#/"}`);
+  });
+});


### PR DESCRIPTION
Adds a replacer function to the example, to resolve circular references in a stringified object.

fixes #58