### PR TITLE
upgrade @adobe/react-spectrum which now comes with the slider component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@adobe/react-spectrum": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.6.0.tgz",
-      "integrity": "sha512-zR7X8qJzdSGW7Jzi17YXL17z1xUBF9YnnwrjUKYgBZsP4xpkd7Wl2ltKWv7OR9CFURWrqtlJBwLOLpiPNypFBg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.7.0.tgz",
+      "integrity": "sha512-GfFBdgOhuJHNYwrEan3HezOKXq5K9Xwtc6mrPTYEtB6/ZnBChfxCMj2QGTEVsit3rpFkz1mywVZRPmFMe5NYPA==",
       "requires": {
         "@react-aria/i18n": "^3.2.0",
         "@react-aria/ssr": "^3.0.1",
@@ -33,6 +33,7 @@
         "@react-spectrum/provider": "^3.1.2",
         "@react-spectrum/radio": "^3.1.1",
         "@react-spectrum/searchfield": "^3.1.2",
+        "@react-spectrum/slider": "^3.0.0",
         "@react-spectrum/statuslight": "^3.1.1",
         "@react-spectrum/switch": "^3.1.1",
         "@react-spectrum/text": "^3.1.1",
@@ -2868,16 +2869,16 @@
       }
     },
     "@react-aria/breadcrumbs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.1.1.tgz",
-      "integrity": "sha512-6yqza6lDQL4gZNASmMCVP7nwlNB492ld0AMs3ce7OJWC/30t/HAXOzrfENhnCvAZpk4y5Ow11q8YDrhj5x2jgQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.1.2.tgz",
+      "integrity": "sha512-rrRxHthNF4SRqufOi2nf9ii84weT+SOhEk3cOpgmcLUhQg9G9uFUc53W7LBOrLxG8HvgwMZoktq7ru3fmUFkXg==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/i18n": "^3.1.2",
         "@react-aria/interactions": "^3.2.1",
         "@react-aria/link": "^3.1.2",
-        "@react-aria/utils": "^3.3.0",
-        "@react-types/breadcrumbs": "^3.1.1",
+        "@react-aria/utils": "^3.5.0",
+        "@react-types/breadcrumbs": "^3.2.0",
         "@react-types/shared": "^3.2.1"
       }
     },
@@ -3127,20 +3128,20 @@
       }
     },
     "@react-aria/slider": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-VyyZw3w5WdPK4+TPN42wFlxnqtlUodU2AyNHvnHcjppTVTiVx92cs6u+t3X7IwmgtjWKrVtoclwoQk/H9b10/w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.0.0.tgz",
+      "integrity": "sha512-IyAzlkgplD1NCxSF9TDL7WxasAOGB2HhosWg1W7WUI9BvzHLeHWsJdpCbTeqHYIlyjZbAdgI2G48NntZU77CyA==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/focus": "^3.2.3",
         "@react-aria/i18n": "^3.1.3",
         "@react-aria/interactions": "^3.3.0",
         "@react-aria/label": "^3.1.1",
-        "@react-aria/utils": "^3.4.0",
+        "@react-aria/utils": "^3.5.0",
         "@react-stately/radio": "^3.2.1",
-        "@react-stately/slider": "3.0.0-alpha.3",
+        "@react-stately/slider": "^3.0.0",
         "@react-types/radio": "^3.1.1",
-        "@react-types/slider": "3.0.0-alpha.2"
+        "@react-types/slider": "^3.0.0"
       }
     },
     "@react-aria/ssr": {
@@ -3241,9 +3242,9 @@
       }
     },
     "@react-aria/utils": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.4.1.tgz",
-      "integrity": "sha512-jG9RJF9vv6Hv/WxvdD8IZSVsLpqP6dLH9zymVd0AURQQHR8QPpm+NHRX0YYZoQR4aQpjNM7OEqMH2LuOEDQeTQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.5.0.tgz",
+      "integrity": "sha512-HjeqT4//N2Jz2WNg3qAg1MpxAjcP+aPR1fq8yXm812za2/bA5rUSZqN0EXHZ9/+NdQhnZoRPNyXN/BJMZJe+Ig==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/ssr": "^3.0.1",
@@ -3675,21 +3676,21 @@
       }
     },
     "@react-spectrum/slider": {
-      "version": "3.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.0.0-alpha.0.tgz",
-      "integrity": "sha512-aU0lgs1tFAtXiEl4+TuHTxyMI9OQ3xmUBhN4vjiMm6UjrByb+rkcIfc/pqZmuXH4Xs8tC0dQcMpuYwcoKwCwJg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-spectrum/slider/-/slider-3.0.0.tgz",
+      "integrity": "sha512-/h7UHvE6Z1nDoFVPdOqyPlf6Txm9X0twXuTfoTuzifdCpd23nIrynZIutEtjVQXsviyrHNdksRSBYrCybW3e1Q==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/focus": "^3.2.3",
         "@react-aria/i18n": "^3.1.3",
         "@react-aria/interactions": "^3.3.0",
-        "@react-aria/slider": "3.0.0-alpha.3",
-        "@react-aria/utils": "^3.4.0",
+        "@react-aria/slider": "^3.0.0",
+        "@react-aria/utils": "^3.5.0",
         "@react-aria/visually-hidden": "3.2.1",
         "@react-spectrum/utils": "^3.4.0",
-        "@react-stately/slider": "3.0.0-alpha.3",
+        "@react-stately/slider": "^3.0.0",
         "@react-types/shared": "^3.3.0",
-        "@react-types/slider": "3.0.0-alpha.2"
+        "@react-types/slider": "^3.0.0"
       }
     },
     "@react-spectrum/statuslight": {
@@ -4014,15 +4015,15 @@
       }
     },
     "@react-stately/slider": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-xrTdbU3p5361bs6UOGqNvddNoqPh7obPYrkj5RhmE+8f/3bL+bROnftK3WdX1n5a+e8fy2iHJug2mqOk2Fgaew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.0.0.tgz",
+      "integrity": "sha512-KAzAhDOF+diyC2k3SPebK9VUKvuXT6wR3BLaAKJYvWMP4EWxoDhRCyc7tHJRKeoCqKiT2qbYd6D1lQDA01foew==",
       "requires": {
         "@babel/runtime": "^7.6.2",
         "@react-aria/i18n": "^3.1.3",
-        "@react-aria/utils": "^3.4.0",
+        "@react-aria/utils": "^3.5.0",
         "@react-stately/utils": "^3.1.1",
-        "@react-types/slider": "3.0.0-alpha.2"
+        "@react-types/slider": "^3.0.0"
       }
     },
     "@react-stately/table": {
@@ -4111,9 +4112,9 @@
       }
     },
     "@react-types/breadcrumbs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.1.1.tgz",
-      "integrity": "sha512-+zmgqouZ+2CIKRDTjHHVjMqu9tlZv9zQltB89z+PZYZRnXeDH+nk0qvNTWsxq0O/+xGJgazAOu0lMXlvEF7WlQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.2.0.tgz",
+      "integrity": "sha512-LmYOZwEbVl3QnjCmc6H3qVTukAQ2mAzwP2jxzmAnzk3dD+jPhsij/G8PWgTZI3oXCM/vSmLxqG8ga7FtrAx2SQ==",
       "requires": {
         "@react-types/shared": "^3.2.1"
       }
@@ -4288,9 +4289,9 @@
       "integrity": "sha512-i/OJplVPIHVok0Bu2Hn9pmz6eyULq2ao6pG/Is8YoDzp33SzumOtXxumgYcaXMJ7wBd2RgPd532m3+RnOY0ndg=="
     },
     "@react-types/slider": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-k6BEYcxLGa/g86RwX0s2gKw5InSqjfu2dkHQlNeU293PMSKXOnOkSHCEVkwLZitxBl8bdnShGdMnvXxHYXeqlg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.0.0.tgz",
+      "integrity": "sha512-BjSnzPcxw8y+PiNQm81X7dSyJwU86UK8ig0YWA2T2m7XhTvy26AjLmUwRDxhhVXAqRQtvRDLd+uowrb9FnWMcQ==",
       "requires": {
         "@react-types/shared": "^3.3.0"
       }
@@ -6517,16 +6518,29 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "version": "1.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.5.tgz",
+      "integrity": "sha512-yoqps/VCaZgN4pfXtenwHROTp8NG6/Hlt4Jpz2FEP0ZJQ+ZUkVDd0hAPDNKhj3nakpfPt/CNs57yEtxD1bXQiw==",
       "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
+        "cheerio-select-tmp": "^0.1.0",
+        "dom-serializer": "~1.2.0",
+        "domhandler": "^4.0.0",
+        "entities": "~2.1.0",
+        "htmlparser2": "^6.0.0",
+        "parse5": "^6.0.0",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0"
+      }
+    },
+    "cheerio-select-tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select-tmp/-/cheerio-select-tmp-0.1.0.tgz",
+      "integrity": "sha512-kx/pq9hxLo6FhjiYqUheSOV0Eb729ZwkXXPrPTeK6kl/VMgaUlsYoAOv3nOJZcHk++V9pI17YNNngtbLVPTB9A==",
+      "requires": {
+        "css-select": "^3.1.2",
+        "css-what": "^4.0.0",
+        "domelementtype": "^2.1.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4"
       }
     },
     "chokidar": {
@@ -8081,14 +8095,15 @@
       }
     },
     "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-3.1.2.tgz",
+      "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
       "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
+        "boolbase": "^1.0.0",
+        "css-what": "^4.0.0",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.3",
+        "nth-check": "^2.0.0"
       }
     },
     "css-selector-tokenizer": {
@@ -8101,9 +8116,9 @@
       }
     },
     "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-4.0.0.tgz",
+      "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A=="
     },
     "css.escape": {
       "version": "1.5.1",
@@ -8585,12 +8600,13 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.2.0.tgz",
+      "integrity": "sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==",
       "requires": {
-        "domelementtype": "^1.3.0",
-        "entities": "^1.1.1"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "entities": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -8600,9 +8616,9 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.1.0.tgz",
+      "integrity": "sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -8613,20 +8629,21 @@
       }
     },
     "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.0.0.tgz",
+      "integrity": "sha512-KPTbnGQ1JeEMQyO1iYXoagsI6so/C96HZiFyByU3T6iAzpXn8EGEvct6unm1ZGoed8ByO2oirxgwxBmqKF9haA==",
       "requires": {
-        "domelementtype": "1"
+        "domelementtype": "^2.1.0"
       }
     },
     "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
+      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0"
       }
     },
     "dot-prop": {
@@ -8758,9 +8775,9 @@
       }
     },
     "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "env-paths": {
       "version": "2.2.0",
@@ -10728,28 +10745,14 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
     },
     "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.0.0.tgz",
+      "integrity": "sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==",
       "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.4.4",
+        "entities": "^2.0.0"
       }
     },
     "http-cache-semantics": {
@@ -14327,11 +14330,11 @@
       }
     },
     "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
       "requires": {
-        "boolbase": "~1.0.0"
+        "boolbase": "^1.0.0"
       }
     },
     "number-is-nan": {
@@ -15037,11 +15040,16 @@
       }
     },
     "parse5": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+    },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "requires": {
-        "@types/node": "*"
+        "parse5": "^6.0.1"
       }
     },
     "parseurl": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -3,11 +3,10 @@
   "version": "2.4.1-beta.0",
   "private": true,
   "dependencies": {
-    "@adobe/react-spectrum": "^3.6.0",
+    "@adobe/react-spectrum": "^3.7.0",
     "@jsonforms/core": "^2.4.1",
     "@jsonforms/examples": "^2.4.1",
     "@jsonforms/react": "^2.4.1",
-    "@react-spectrum/slider": "^3.0.0-alpha.0",
     "@react-spectrum/table": "^3.0.0-alpha.9",
     "@react-spectrum/tabs": "^3.0.0-alpha.3",
     "@spectrum-icons/workflow": "^3.2.0",

--- a/packages/spectrum/package.json
+++ b/packages/spectrum/package.json
@@ -46,10 +46,9 @@
     "uuid": "^3.3.3"
   },
   "peerDependencies": {
-    "@adobe/react-spectrum": "^3.6.0",
+    "@adobe/react-spectrum": "^3.7.0",
     "@jsonforms/core": "^2.4.1",
     "@jsonforms/react": "^2.4.1",
-    "@react-spectrum/slider": "^3.0.0-alpha.0",
     "@react-spectrum/table": "^3.0.0-alpha.9",
     "@react-spectrum/tabs": "^3.0.0-alpha.3",
     "@spectrum-icons/workflow": "^3.2.0",

--- a/packages/spectrum/src/spectrum-control/InputSlider.tsx
+++ b/packages/spectrum/src/spectrum-control/InputSlider.tsx
@@ -27,7 +27,7 @@ import { CellProps } from '@jsonforms/core';
 import { merge } from 'lodash';
 import { DimensionValue } from '@react-types/shared';
 import { SpectrumInputProps } from './index';
-import { Slider } from '@react-spectrum/slider';
+import { Slider } from '@adobe/react-spectrum';
 
 export class InputSlider extends React.PureComponent<
   CellProps & SpectrumInputProps


### PR DESCRIPTION
The slider component was pushed out of alpha and is now part of `@adobe/react-spectrum` with the new 3.7.0 release.

- [x] upgrade to `@adobe/react-spectrum 3.7.0`
- [x] remove dependency to `react-spectrum/slider` (alpha)
- [x] import the slider component from `@adobe/react-spectrum`